### PR TITLE
[TISDEV-5036] Enable prometheus for monitoring

### DIFF
--- a/generic-upload-service/pom.xml
+++ b/generic-upload-service/pom.xml
@@ -12,7 +12,7 @@
 
 	<groupId>com.transformuk.hee.tis</groupId>
 	<artifactId>generic-upload-service</artifactId>
-	<version>1.1.8</version>
+	<version>1.2.0</version>
 	<packaging>war</packaging>
 
 	<properties>
@@ -202,6 +202,21 @@
 		</dependency>
 		<!-- Custom end -->
 
+    <dependency>
+      <groupId>io.prometheus</groupId>
+      <artifactId>simpleclient</artifactId>
+      <version>${prometheus-simpleclient.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.prometheus</groupId>
+      <artifactId>simpleclient_servlet</artifactId>
+      <version>${prometheus-simpleclient.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.prometheus</groupId>
+      <artifactId>simpleclient_dropwizard</artifactId>
+      <version>${prometheus-simpleclient.version}</version>
+    </dependency>
 		<dependency>
 			<groupId>io.github.jhipster</groupId>
 			<artifactId>jhipster</artifactId>

--- a/generic-upload-service/src/main/resources/config/application-prod.yml
+++ b/generic-upload-service/src/main/resources/config/application-prod.yml
@@ -131,7 +131,7 @@ jhipster:
             port: 2003
             prefix: assessments
         prometheus:
-            enabled: false
+            enabled: true
             endpoint: /prometheusMetrics
         logs: # Reports Dropwizard metrics in the logs
             enabled: false

--- a/generic-upload-service/src/main/resources/config/application.yml
+++ b/generic-upload-service/src/main/resources/config/application.yml
@@ -30,7 +30,7 @@ spring:
         # Otherwise, it will be filled in by maven when building the WAR file
         # Either way, it can be overridden by `--spring.profiles.active` value passed in the commandline or `-Dspring.profiles.active` set in `JAVA_OPTS`
 #        active: #spring.profiles.active#
-        active: prod
+        active: prod,prometheus
     jackson:
         serialization.write_dates_as_timestamps: false
         date-format: dd/MM/yyyy


### PR DESCRIPTION
We need to be able to monitor JMX stats so we can better utilise performance and tune our applications. To do this we need to export out metrics from the applications, push them to promethus and then capture them in grafana.

That we can we better understand what's going on with garbage collection and problems with heap sizes.

To do this we've exposed the built in metrics exporter of jhipster which allows us to then pick this up from the /promethusMetrics endpoint from prometheus.

Then we can pick these up with grafana.