### PR TITLE
Add validation for the dates of assessments.

### DIFF
--- a/generic-upload-service/src/main/java/com/transformuk/hee/tis/genericupload/service/api/validation/FileValidator.java
+++ b/generic-upload-service/src/main/java/com/transformuk/hee/tis/genericupload/service/api/validation/FileValidator.java
@@ -28,7 +28,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 @Component
 public class FileValidator {
 
-	public static final String DATE_MISSING_ON_MANDATORY_FIELD  = "Date missing or incorrect format on mandatory field (%1$s)";
+	public static final String DATE_MISSING_OR_INVALID_ON_MANDATORY_FIELD = "Date missing or incorrect format on mandatory field (%1$s)";
 	public static final String FIELD_IS_REQUIRED_AT_LINE_NO = "%s Field is required at line no %d ";
 	private final Logger logger = LoggerFactory.getLogger(UploadFileResource.class);
 
@@ -133,7 +133,7 @@ public class FileValidator {
 				Date date = (Date) currentField.get(row);//TODO should throw an exception on invalid date
 				if (date == null) {
 					fieldErrors.add(new FieldError(mappedToClass.getSimpleName(), columnNameToMandatoryColumnsMapKey,
-							String.format(DATE_MISSING_ON_MANDATORY_FIELD, columnNameToMandatoryColumnsMapKey)));
+							String.format(DATE_MISSING_OR_INVALID_ON_MANDATORY_FIELD, columnNameToMandatoryColumnsMapKey)));
 				}
 			} else if(currentField.getType() == Float.class) {
 				//TODO validate Float Fields

--- a/generic-upload-service/src/main/java/com/transformuk/hee/tis/genericupload/service/config/MapperConfiguration.java
+++ b/generic-upload-service/src/main/java/com/transformuk/hee/tis/genericupload/service/config/MapperConfiguration.java
@@ -27,11 +27,17 @@ public abstract class MapperConfiguration {
         return result;
     }
 
-    public static LocalDate convertDate(Date date) {
+    public static LocalDate convertDate(Date date) throws IllegalArgumentException {
         LocalDate localDate = null;
         if (date != null) {
             final Calendar cal = Calendar.getInstance();
             cal.setTime(date);
+
+            // As agreed with TIS head business analysis, we should only allow years after 1753
+            // because the NDW uses SQL Server for which the lowest allowed date field year is 1753
+            if (cal.get(Calendar.YEAR) < 1753) {
+                throw new IllegalArgumentException("The year cannot be less than 1753");
+            }
 
             //plus 1 on month as month starts from zero in a Calendar object
             localDate = LocalDate.of(cal.get(Calendar.YEAR), cal.get(Calendar.MONTH) + 1, cal.get(Calendar.DAY_OF_MONTH));


### PR DESCRIPTION
There has been now few occasions after generic upload was released where assessments contain invalid dates uploaded via the bulk upload and this caused NDW to get truncated. These dates are invalid in the eyes of SQL server while TIS approves them. This is due to usage of different databases engines. TIS uses MySQL where as NDW is using SQL Server. To sort this, this PR introduces basic error handling for the assessment upload dates. 

Generally, I feel there's a huge space for improvement in the generic upload to generalize the error handling instead of doing it on field-by-field basis but this is a quick fix needed to prevent this from happening all the time.