### PR TITLE
[TISNEW-2165] - AssessmentTransformerService updated with logic to populate fields

### DIFF
--- a/generic-upload-service/pom.xml
+++ b/generic-upload-service/pom.xml
@@ -12,7 +12,7 @@
 
 	<groupId>com.transformuk.hee.tis</groupId>
 	<artifactId>generic-upload-service</artifactId>
-	<version>1.2.34</version>
+	<version>1.2.35</version>
 	<packaging>war</packaging>
 
 	<properties>
@@ -158,7 +158,7 @@
 		<dependency>
 			<groupId>com.transformuk.hee.tis</groupId>
 			<artifactId>tcs-client</artifactId>
-			<version>3.0.72</version>
+			<version>3.0.76</version>
 		</dependency>
 		<dependency>
 			<groupId>com.transformuk.hee</groupId>


### PR DESCRIPTION
-  AssessmentTransformerService updated to include logic that populates gradeId, gradeAbbreviation and gradeName
- Currently the logic to populate the fields exist on the FE and when a user creates a new record, it is applied. When a user creates a new record via the bulk upload functionality, there is not interaction with that piece of FE logic which leads to the above mentioned fields being blank in TIS and the NDW. This fixes that issue.