### PR TITLE
Perform some cleanup in PostUpdateTransformerService

### DIFF
--- a/generic-upload-api/pom.xml
+++ b/generic-upload-api/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>generic-upload-api</artifactId>
-  <version>1.0.4</version>
+  <version>1.1.0</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/generic-upload-api/src/main/java/com/transformuk/hee/tis/genericupload/api/dto/PostUpdateXLS.java
+++ b/generic-upload-api/src/main/java/com/transformuk/hee/tis/genericupload/api/dto/PostUpdateXLS.java
@@ -4,7 +4,7 @@ import java.util.Date;
 import java.util.Objects;
 
 public class PostUpdateXLS extends TemplateXLS{
-  private String postTISTd;
+  private String postTISId;
   private String approvedGrade;
   private String otherGrades;
   private String specialty;
@@ -27,12 +27,12 @@ public class PostUpdateXLS extends TemplateXLS{
   private Date dateFrom;
   private Date dateTo;
 
-  public String getPostTISTd() {
-    return postTISTd;
+  public String getPostTISId() {
+    return postTISId;
   }
 
-  public void setPostTISTd(String postTISTd) {
-    this.postTISTd = postTISTd;
+  public void setPostTISId(String postTISId) {
+    this.postTISId = postTISId;
   }
 
   public String getApprovedGrade() {
@@ -208,7 +208,7 @@ public class PostUpdateXLS extends TemplateXLS{
     if (this == o) return true;
     if (!(o instanceof PostUpdateXLS)) return false;
     PostUpdateXLS that = (PostUpdateXLS) o;
-    return Objects.equals(getPostTISTd(), that.getPostTISTd()) &&
+    return Objects.equals(getPostTISId(), that.getPostTISId()) &&
         Objects.equals(getApprovedGrade(), that.getApprovedGrade()) &&
         Objects.equals(getOtherGrades(), that.getOtherGrades()) &&
         Objects.equals(getSpecialty(), that.getSpecialty()) &&
@@ -235,13 +235,13 @@ public class PostUpdateXLS extends TemplateXLS{
   @Override
   public int hashCode() {
 
-    return Objects.hash(getPostTISTd(), getApprovedGrade(), getOtherGrades(), getSpecialty(), getOtherSpecialties(), getSubSpecialties(), getTrainingDescription(), getMainSite(), getOtherSites(), getTrainingBody(), getEmployingBody(), getProgrammeName(), getProgrammeNo(), getOwner(), getRotation(), getStatus(), getOldPost(), getFundingType(), getFundingTypeOther(), getFundingBody(), getDateFrom(), getDateTo());
+    return Objects.hash(getPostTISId(), getApprovedGrade(), getOtherGrades(), getSpecialty(), getOtherSpecialties(), getSubSpecialties(), getTrainingDescription(), getMainSite(), getOtherSites(), getTrainingBody(), getEmployingBody(), getProgrammeName(), getProgrammeNo(), getOwner(), getRotation(), getStatus(), getOldPost(), getFundingType(), getFundingTypeOther(), getFundingBody(), getDateFrom(), getDateTo());
   }
 
   @Override
   public String toString() {
     return "PostUpdateXLS{" +
-        "postTISTd='" + postTISTd + '\'' +
+        "postTISId='" + postTISId + '\'' +
         ", approvedGrade='" + approvedGrade + '\'' +
         ", otherGrades='" + otherGrades + '\'' +
         ", specialty='" + specialty + '\'' +

--- a/generic-upload-client/pom.xml
+++ b/generic-upload-client/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>generic-upload-client</artifactId>
-  <version>1.0.2</version>
+  <version>1.1.0</version>
   <packaging>jar</packaging>
 
   <properties>
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>com.transformuk.hee.tis</groupId>
       <artifactId>generic-upload-api</artifactId>
-      <version>1.0.4</version>
+      <version>1.1.0</version>
     </dependency>
     <dependency>
       <groupId>com.transformuk.hee</groupId>

--- a/generic-upload-service/pom.xml
+++ b/generic-upload-service/pom.xml
@@ -12,7 +12,7 @@
 
 	<groupId>com.transformuk.hee.tis</groupId>
 	<artifactId>generic-upload-service</artifactId>
-	<version>1.2.41</version>
+	<version>1.3.0</version>
 	<packaging>war</packaging>
 
 	<properties>
@@ -153,7 +153,7 @@
 		<dependency>
 			<groupId>com.transformuk.hee.tis</groupId>
 			<artifactId>tcs-client</artifactId>
-			<version>4.0.2</version>
+			<version>4.1.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.transformuk.hee</groupId>
@@ -178,7 +178,7 @@
 		<dependency>
 			<groupId>com.transformuk.hee.tis</groupId>
 			<artifactId>generic-upload-api</artifactId>
-			<version>1.0.4</version>
+			<version>1.1.0</version>
 		</dependency>
 		<!-- TIS END -->
 


### PR DESCRIPTION
Update PostUpdateTransformerService to handle error message output
properly, change boolean parameters for the enumerations that they
represent and construct DTOs with parameters rather than setting each
individually.

Update service pom.xml to bump the tcs-client dependency version and
bump the generic-upload-service version.

Update PostUpdateXLS to fix a typo in the postTisId field.

Update api pom.xml to bump the generic-upload-api version.