### PR TITLE
Allow update of NI number during bulk upload

### DIFF
--- a/generic-upload-service/pom.xml
+++ b/generic-upload-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>generic-upload-service</artifactId>
-  <version>1.7.0</version>
+  <version>1.8.0</version>
   <packaging>war</packaging>
 
   <properties>

--- a/generic-upload-service/src/main/java/com/transformuk/hee/tis/genericupload/service/service/PersonTransformerService.java
+++ b/generic-upload-service/src/main/java/com/transformuk/hee/tis/genericupload/service/service/PersonTransformerService.java
@@ -387,7 +387,7 @@ public class PersonTransformerService {
     copyIfNotNullOrEmpty(personDTOFromXLS.getPersonalDetails(),
         personDTOFromDB.getPersonalDetails(),
         "maritalStatus", "dateOfBirth", "disability", "disabilityDetails", "nationality", "gender",
-        "ethnicOrigin", "sexualOrientation", "religiousBelief");
+        "ethnicOrigin", "sexualOrientation", "religiousBelief", "nationalInsuranceNumber");
     copyIfNotNullOrEmpty(personDTOFromXLS.getGmcDetails(), personDTOFromDB.getGmcDetails(),
         "gmcNumber");
     copyIfNotNullOrEmpty(personDTOFromXLS.getGdcDetails(), personDTOFromDB.getGdcDetails(),


### PR DESCRIPTION
Currently the NI field on the person bulk update template is ignored
when uploaded. This should be changed to allow the update of the NI
number to be processed.