### PR TITLE
fix: Only mark successful when no errors occur

### DIFF
--- a/generic-upload-service/src/main/java/com/transformuk/hee/tis/genericupload/service/service/PostCreateTransformerService.java
+++ b/generic-upload-service/src/main/java/com/transformuk/hee/tis/genericupload/service/service/PostCreateTransformerService.java
@@ -87,7 +87,7 @@ public class PostCreateTransformerService {
     if (!postDtos.isEmpty()) {
       // TODO: create endpoint
       tcsService.bulkCreateDto(postDtos, "/api/bulk-posts", PostDTO.class);
-      xlsList.forEach(x -> x.setSuccessfullyImported(true));
+      xlsList.forEach(x -> x.setSuccessfullyImported(!x.hasErrors()));
     }
   }
 


### PR DESCRIPTION
The successful import flag was being set to true for all XLS, instead of
only those without errors. Add a check for errors before setting the
flag.

TISNEW-3650