### PR TITLE
feat: Allow FileType to determine correct XLS DTO

### DIFF
--- a/generic-upload-api/pom.xml
+++ b/generic-upload-api/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>generic-upload-api</artifactId>
-  <version>1.8.0</version>
+  <version>1.9.0</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/generic-upload-api/src/main/java/com/transformuk/hee/tis/genericupload/api/enumeration/FileType.java
+++ b/generic-upload-api/src/main/java/com/transformuk/hee/tis/genericupload/api/enumeration/FileType.java
@@ -1,13 +1,37 @@
 package com.transformuk.hee.tis.genericupload.api.enumeration;
 
+import com.transformuk.hee.tis.genericupload.api.dto.AssessmentXLS;
+import com.transformuk.hee.tis.genericupload.api.dto.FundingUpdateXLS;
+import com.transformuk.hee.tis.genericupload.api.dto.PersonXLS;
+import com.transformuk.hee.tis.genericupload.api.dto.PlacementDeleteXLS;
+import com.transformuk.hee.tis.genericupload.api.dto.PlacementUpdateXLS;
+import com.transformuk.hee.tis.genericupload.api.dto.PlacementXLS;
+import com.transformuk.hee.tis.genericupload.api.dto.PostCreateXls;
+import com.transformuk.hee.tis.genericupload.api.dto.PostFundingUpdateXLS;
+import com.transformuk.hee.tis.genericupload.api.dto.PostUpdateXLS;
+import com.transformuk.hee.tis.genericupload.api.dto.TemplateXLS;
+import lombok.Getter;
+
 public enum FileType {
-  ASSESSMENTS,
-  FUNDING_UPDATE,
-  PEOPLE,
-  PLACEMENTS,
-  PLACEMENTS_DELETE,
-  PLACEMENTS_UPDATE,
-  POSTS_CREATE,
-  POSTS_UPDATE,
-  POSTS_FUNDING_UPDATE
+  ASSESSMENTS(AssessmentXLS.class),
+  FUNDING_UPDATE(FundingUpdateXLS.class),
+  PEOPLE(PersonXLS.class),
+  PLACEMENTS(PlacementXLS.class),
+  PLACEMENTS_DELETE(PlacementDeleteXLS.class),
+  PLACEMENTS_UPDATE(PlacementUpdateXLS.class),
+  POSTS_CREATE(PostCreateXls.class),
+  POSTS_UPDATE(PostUpdateXLS.class),
+  POSTS_FUNDING_UPDATE(PostFundingUpdateXLS.class);
+
+  /**
+   * The class of the XLS DTO related to this FileType.
+   *
+   * @return The associated class.
+   */
+  @Getter
+  private final Class<? extends TemplateXLS> dtoClass;
+
+  FileType(Class<? extends TemplateXLS> dtoClass) {
+    this.dtoClass = dtoClass;
+  }
 }


### PR DESCRIPTION
Care must be taken to ensure that the correct XLS DTO is used after
identifying the file type. To reduce the chance of mistakes the FileType
can instead provide the associated class itself.

Bump the generic-upload-api minor version.

TISNEW-3857