### PR TITLE
fix: set Role to mandatory in PersonXLS

### DIFF
--- a/generic-upload-api/pom.xml
+++ b/generic-upload-api/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>generic-upload-api</artifactId>
-  <version>1.10.1</version>
+  <version>1.10.2</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/generic-upload-api/src/main/java/com/transformuk/hee/tis/genericupload/api/dto/PersonXLS.java
+++ b/generic-upload-api/src/main/java/com/transformuk/hee/tis/genericupload/api/dto/PersonXLS.java
@@ -132,7 +132,7 @@ public class PersonXLS extends TemplateXLS {
   @ExcelColumn(name = "Programme End Date")
   private Date programmeEndDate;
 
-  @ExcelColumn(name = "Role")
+  @ExcelColumn(name = "Role *", required = true)
   private String role;
 
   @ExcelColumn(name = "Known As")

--- a/generic-upload-service/pom.xml
+++ b/generic-upload-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>generic-upload-service</artifactId>
-  <version>1.16.0</version>
+  <version>1.16.1</version>
   <packaging>war</packaging>
 
   <properties>
@@ -153,7 +153,7 @@
     <dependency>
       <groupId>com.transformuk.hee.tis</groupId>
       <artifactId>generic-upload-api</artifactId>
-      <version>1.10.1</version>
+      <version>1.10.2</version>
     </dependency>
     <dependency>
       <groupId>uk.nhs.tis</groupId>


### PR DESCRIPTION
When role is emtpy, generic upload also show validation message on top of upload jobs.
Although tcs validates Role fields and throws error in template file, this fix will activate the validation from generic upload service.

TIS21-1752