### PR TITLE
fix: show errMsg when reasons are not needed for assessment update

### DIFF
--- a/generic-upload-service/pom.xml
+++ b/generic-upload-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>generic-upload-service</artifactId>
-  <version>1.17.1</version>
+  <version>1.17.2</version>
 
   <packaging>war</packaging>
 

--- a/generic-upload-service/src/main/java/com/transformuk/hee/tis/genericupload/service/service/AssessmentUpdateTransformerService.java
+++ b/generic-upload-service/src/main/java/com/transformuk/hee/tis/genericupload/service/service/AssessmentUpdateTransformerService.java
@@ -78,6 +78,8 @@ public class AssessmentUpdateTransformerService {
       "Given Assessment reason not found for: %s.";
   public static final String NOT_ASSESSED_REASON_IS_REQUIRED =
       "Unsatisfactory Outcome/Not Assessed Reason is required when Other reason is updating";
+  public static final String NOT_ASSESSED_REASONS_SHOULD_BE_EMPTY_FOR_OUTCOME =
+      "Not assessed reason should be empty for outcome: %s";
   public static final String ACADEMIC_OUTCOME_IS_REQUIRED = "Academic outcome is required.";
   public static final String ACADEMIC_OUTCOME_NOT_EXISTS = "Academic outcome value does not exist.";
   public static final String PYA_SHOULD_BE_BOOLEAN = "Pya should be YES/NO.";
@@ -87,8 +89,8 @@ public class AssessmentUpdateTransformerService {
   public static final String TEN_PERCENT_AUDIT_SHOULD_BE_BOOLEAN =
       "Set 10% audit - lay member should be YES/NO.";
   public static final String KNOWN_CONCERNS_SHOULD_BE_BOOLEAN = "Known concerns should be YES/NO.";
-  protected static final String[] academicCurricula = {"AFT", "ACLNIHR_FUNDING", "ACL_OTHER_FUNDING",
-      "ACFNIHR_FUNDING", "ACF_OTHER_FUNDING"};
+  protected static final String[] academicCurricula = {"AFT", "ACLNIHR_FUNDING",
+      "ACL_OTHER_FUNDING", "ACFNIHR_FUNDING", "ACF_OTHER_FUNDING"};
   protected static final String[] academicOutcomes = {"Continue on academic component",
       "Do not continue on academic component", "Successfully completed academic component"};
 
@@ -303,16 +305,24 @@ public class AssessmentUpdateTransformerService {
     }
 
     // Reasons
+    Set<Reason> outcomeReasons = outcome.getReasons();
+    // When outcome does not need a reason, but reasons are input.
+    if (CollectionUtils.isEmpty(outcomeReasons) && (notAssessedReasonFromXls
+        || otherReasonFromXls)) {
+      xls.addErrorMessage(
+          String.format(NOT_ASSESSED_REASONS_SHOULD_BE_EMPTY_FOR_OUTCOME, outcomeLabel));
+      return;
+    }
     // When otherReason is input, the notAssessedReason is required.
     if (!notAssessedReasonFromXls && otherReasonFromXls) {
       xls.addErrorMessage(NOT_ASSESSED_REASON_IS_REQUIRED);
       return;
     }
-    Set<Reason> outcomeReasons = outcome.getReasons();
+    // When outcome needs a reason, check if reason is input.
     if (!CollectionUtils.isEmpty(outcomeReasons)) {
       if (!notAssessedReasonFromXls) {
         xls.addErrorMessage(
-            String.format(OUTCOME_REASON_IS_REQUIRED_FOR_OUTCOME_S, xls.getOutcome()));
+            String.format(OUTCOME_REASON_IS_REQUIRED_FOR_OUTCOME_S, outcomeLabel));
       } else {
         List<String> notAssessedReasons = Arrays.asList(
             xls.getOutcomeNotAssessed().split(SEMI_COLON));

--- a/generic-upload-service/src/test/java/com/transformuk/hee/tis/genericupload/service/service/AssessmentUpdateTransformerServiceTest.java
+++ b/generic-upload-service/src/test/java/com/transformuk/hee/tis/genericupload/service/service/AssessmentUpdateTransformerServiceTest.java
@@ -91,9 +91,15 @@ public class AssessmentUpdateTransformerServiceTest {
     outcome2.setId(2L);
     outcome2.setLabel("Outcome_2");
     Set<Outcome> outcomes = new HashSet<>();
+    outcome2.setReasons(reasonSet1);
+
+    Outcome outcome3 = new Outcome();
+    outcome3.setId(3L);
+    outcome3.setLabel("Outcome_3");
+
     outcomes.add(outcome1);
     outcomes.add(outcome2);
-    outcome2.setReasons(reasonSet1);
+    outcomes.add(outcome3);
     when(assessmentTransformerServiceMock.getAllOutcomes()).thenReturn(outcomes);
   }
 
@@ -467,6 +473,30 @@ public class AssessmentUpdateTransformerServiceTest {
     assessmentUpdateTransformerService.processAssessmentsUpdateUpload(xlsList);
     assertThat("Should get error", xlsList.get(0).getErrorMessage(),
         is(AssessmentUpdateTransformerService.OUTCOME_CANNOT_BE_IDENTIFIED));
+  }
+
+  @Test
+  public void testProcessAssessmentsUpdateUpload_reasonsShouldNotBeInput() {
+    // Existing Assessment
+    String id = "1";
+    AssessmentDTO assessmentDto = new AssessmentDTO();
+    assessmentDto.id(Long.valueOf(id));
+    assessmentDto.setTraineeId(1L);
+    when(assessmentServiceMock.findAssessmentByIds(Collections.singleton(id))).thenReturn(
+        Collections.singletonList(assessmentDto));
+
+    // AssessmentUpdateXLS to update
+    AssessmentUpdateXLS xls = new AssessmentUpdateXLS();
+    xls.setAssessmentId(id);
+    xls.setOutcome("Outcome_3");
+    xls.setOutcomeNotAssessed("reason_1");
+    List<AssessmentUpdateXLS> xlsList = Collections.singletonList(xls);
+
+    assessmentUpdateTransformerService.processAssessmentsUpdateUpload(xlsList);
+    assertThat("Should get error", xlsList.get(0).getErrorMessage(),
+        is(String.format(
+            AssessmentUpdateTransformerService.NOT_ASSESSED_REASONS_SHOULD_BE_EMPTY_FOR_OUTCOME,
+            xls.getOutcome())));
   }
 
   @Test


### PR DESCRIPTION
When outcome does not need a reason and not assessed reason is input, give users a error message.

TIS21-181