### PR TITLE
fix: set correct npn for Placement create/update

### DIFF
--- a/generic-upload-service/pom.xml
+++ b/generic-upload-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>generic-upload-service</artifactId>
-  <version>1.18.2</version>
+  <version>1.18.3</version>
 
   <packaging>war</packaging>
 

--- a/generic-upload-service/src/main/java/com/transformuk/hee/tis/genericupload/service/service/PlacementTransformerService.java
+++ b/generic-upload-service/src/main/java/com/transformuk/hee/tis/genericupload/service/service/PlacementTransformerService.java
@@ -321,6 +321,7 @@ public class PlacementTransformerService {
       }
       if (placementsByPostIdAndPersonId.isEmpty() || !existingPlacementUpdatedOrDeleted) {
         PlacementDetailsDTO placementDTO = new PlacementDetailsDTO();
+        placementDTO.setNationalPostNumber(postDTO.getNationalPostNumber());
         placementDTO.setTraineeId(personBasicDetailsDTO.getId());
         placementDTO.setPostId(postDTO.getId());
         placementDTO.setDateFrom(dateFrom);

--- a/generic-upload-service/src/main/java/com/transformuk/hee/tis/genericupload/service/service/PlacementUpdateTransformerService.java
+++ b/generic-upload-service/src/main/java/com/transformuk/hee/tis/genericupload/service/service/PlacementUpdateTransformerService.java
@@ -120,6 +120,7 @@ public class PlacementUpdateTransformerService {
         PostDTO postDTO = null;
         if (placementXLS.getNationalPostNumber() != null) {
           if (isNPNValid(placementXLS, nationalPostNumber, postsMappedByNPNs, duplicateNPNKeys)) {
+            dbPlacementDetailsDTO.setNationalPostNumber(nationalPostNumber);
             postDTO = postsMappedByNPNs.get(nationalPostNumber);
             if (postDTO != null) {
               if ("DELETE".equalsIgnoreCase(postDTO.getStatus().toString())) {


### PR DESCRIPTION
There's a `nationalPostNumber` and a `Post` in `PlacementDetailsDTO`, but the `nationalPostNumber` is not set/updated when bulk uploading. 
The `PlacementDetails` does not have this npn member, so I guess it is probably a redundant field. But to avoid confusion, it should be set correctly.

TIS21-174