### PR TITLE
chore(deps): bump tis-parent-client from 4.2.1 to 5.1.4

### DIFF
--- a/generic-upload-client/pom.xml
+++ b/generic-upload-client/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>generic-upload-client</artifactId>
-  <version>1.5.0</version>
+  <version>1.5.1</version>
   <packaging>jar</packaging>
 
   <properties>
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>com.transformuk.hee</groupId>
       <artifactId>tis-parent-client</artifactId>
-      <version>4.0.1</version>
+      <version>5.1.4</version>
     </dependency>
     <dependency>
       <groupId>com.transformuk.hee.tis</groupId>

--- a/generic-upload-service/pom.xml
+++ b/generic-upload-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>generic-upload-service</artifactId>
-  <version>1.18.3</version>
+  <version>1.18.4</version>
 
   <packaging>war</packaging>
 
@@ -101,7 +101,7 @@
     <dependency>
       <groupId>com.transformuk.hee</groupId>
       <artifactId>tis-parent-client</artifactId>
-      <version>4.0.1</version>
+      <version>5.1.4</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
Bump the version of `tis-parent-client` to `5.1.4` to update transient
dependency `tis-security-jwt` to `5.1.4`, which allows usage with
Cognito/AWS API Gateway.

TIS21-2477, TIS21-2474