### PR TITLE
chore(deps): assessments-client 1.2.1 -> 1.2.3

### DIFF
--- a/generic-upload-service/pom.xml
+++ b/generic-upload-service/pom.xml
@@ -143,13 +143,8 @@
     </dependency>
     <dependency>
       <groupId>com.transformuk.hee.tis</groupId>
-      <artifactId>assessments-api</artifactId>
-      <version>1.5.3</version>
-    </dependency>
-    <dependency>
-      <groupId>com.transformuk.hee.tis</groupId>
       <artifactId>assessments-client</artifactId>
-      <version>1.2.1</version>
+      <version>1.2.3</version>
     </dependency>
     <dependency>
       <groupId>com.transformuk.hee.tis</groupId>


### PR DESCRIPTION
NEEDS: Health-Education-England/TIS-ASSESSMENTS/pull/113

Also removing assessment-api version which should match the client.

NO-TICKETY: Prompted by a Security Vulnerability