### PR TITLE
fix: missing specialtyName when Placement Create/update

### DIFF
--- a/generic-upload-service/pom.xml
+++ b/generic-upload-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>generic-upload-service</artifactId>
-  <version>1.18.8</version>
+  <version>1.18.9</version>
 
   <packaging>war</packaging>
 

--- a/generic-upload-service/src/main/java/com/transformuk/hee/tis/genericupload/service/service/PlacementTransformerService.java
+++ b/generic-upload-service/src/main/java/com/transformuk/hee/tis/genericupload/service/service/PlacementTransformerService.java
@@ -532,6 +532,7 @@ public class PlacementTransformerService {
       PlacementSpecialtyDTO placementSpecialtyDTO = new PlacementSpecialtyDTO();
       placementSpecialtyDTO.setPlacementId(placementDTO.getId());
       placementSpecialtyDTO.setSpecialtyId(specialtyDTO.getId());
+      placementSpecialtyDTO.setSpecialtyName(specialtyName);
       placementSpecialtyDTO
           .setPlacementSpecialtyType(primary ? PostSpecialtyType.PRIMARY : PostSpecialtyType.OTHER);
       return Optional.of(placementSpecialtyDTO);

--- a/generic-upload-service/src/main/java/com/transformuk/hee/tis/genericupload/service/service/PlacementUpdateTransformerService.java
+++ b/generic-upload-service/src/main/java/com/transformuk/hee/tis/genericupload/service/service/PlacementUpdateTransformerService.java
@@ -350,6 +350,7 @@ public class PlacementUpdateTransformerService {
       PlacementSpecialtyDTO placementSpecialtyDTO = new PlacementSpecialtyDTO();
       placementSpecialtyDTO.setPlacementId(placementDTO.getId());
       placementSpecialtyDTO.setSpecialtyId(specialtyDTO.getId());
+      placementSpecialtyDTO.setSpecialtyName(specialtyName);
       placementSpecialtyDTO
           .setPlacementSpecialtyType(primary ? PostSpecialtyType.PRIMARY : PostSpecialtyType.OTHER);
       return Optional.of(placementSpecialtyDTO);


### PR DESCRIPTION
Front end does not allow main specialty, other specialties and Sub-specialty to be setup with the same value. And the bulk upload tended to have the same logic: (https://github.com/Health-Education-England/TIS-GENERIC-UPLOAD/blob/6d683d5c96ae9f022df54f4c2c186e3dd6835658/generic-upload-service/src/main/java/com/transformuk/hee/tis/genericupload/service/service/PlacementUpdateTransformerService.java#L336)
The `placementSpecialtyDTOS.contains(placementSpecialtyDTO)`  uses `hashCode` to check if the dtos are the same and it requires `specialtyName` which is missing. So currently the bulk upload doesn't behave as what we expected.

Besides, the duplication of the placementSpecialty causes an exception of placement.save() too (some logs can be found here: https://eu-west-2.console.aws.amazon.com/cloudwatch/home?region=eu-west-2#logsV2:log-groups/log-group/awslogs-preprod-tis-tcs/log-events/awslogs-tis-tcs$252Ftis-tcs$252F1a845817c74c4e27814f14f930784fa2). 

TIS21-2356