### PR TITLE
fix: map the id from Person to RightToWork

### DIFF
--- a/generic-upload-service/pom.xml
+++ b/generic-upload-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>generic-upload-service</artifactId>
-  <version>1.18.15</version>
+  <version>1.18.16</version>
 
   <packaging>war</packaging>
 

--- a/generic-upload-service/src/main/java/com/transformuk/hee/tis/genericupload/service/service/mapper/RightToWorkMapper.java
+++ b/generic-upload-service/src/main/java/com/transformuk/hee/tis/genericupload/service/service/mapper/RightToWorkMapper.java
@@ -3,9 +3,14 @@ package com.transformuk.hee.tis.genericupload.service.service.mapper;
 import com.transformuk.hee.tis.genericupload.api.dto.PersonUpdateXls;
 import com.transformuk.hee.tis.tcs.api.dto.RightToWorkDTO;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Mappings;
 
 @Mapper(componentModel = "spring")
 public interface RightToWorkMapper {
 
+  @Mappings({
+          @Mapping(source = "tisPersonId", target = "id"),
+  })
   RightToWorkDTO toDto(PersonUpdateXls xls);
 }


### PR DESCRIPTION
When bulk updating the Person, set the RightToWork ID, which is the same as the Person ID.
Person ID is required in the template.

In the [PR of validation on visaDates](https://github.com/Health-Education-England/TIS-TCS/pull/867), the person Id is removed as it's a duplicate of rightToWork Id.

TIS21-505