### PR TITLE
chore: migrate from adopt to temurin in workflows

### DIFF
--- a/.github/workflows/pr-workflow.yml
+++ b/.github/workflows/pr-workflow.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v2.4.0
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Configure AWS credentials


### PR DESCRIPTION
The AdoptOpenJDK project has moved and rebranded to Adoptium, with
Temurin being the naming of the JDK binaries produced by the Adoptium
project.

TIS21-SHED