### PR TITLE
fix: bump assessment-client

### DIFF
--- a/generic-upload-service/pom.xml
+++ b/generic-upload-service/pom.xml
@@ -144,7 +144,7 @@
     <dependency>
       <groupId>com.transformuk.hee.tis</groupId>
       <artifactId>assessments-client</artifactId>
-      <version>1.2.3</version>
+      <version>1.2.4</version>
     </dependency>
     <dependency>
       <groupId>com.transformuk.hee.tis</groupId>


### PR DESCRIPTION
To fix use the CurriculumMembershipId
for checking duplicate assessments.

depends on Assessment: [#127](https://github.com/Health-Education-England/TIS-ASSESSMENTS/pull/127)

TIS21-2422