### PR TITLE
chore(defect): reset status for a single file once

### DIFF
--- a/generic-upload-service/src/main/resources/db/migration/V1.7__retry_failed_file.sql
+++ b/generic-upload-service/src/main/resources/db/migration/V1.7__retry_failed_file.sql
@@ -1,0 +1,6 @@
+UPDATE `ApplicationType`
+SET `status` = 'PENDING'
+WHERE `id` IN(23484, 23511)
+  AND `logId` IN(1663086785784, 1663079220335)
+  AND `fileName` = 'TIS People Update Template (5).xls'
+  AND `status` = 'IN_PROGRESS';


### PR DESCRIPTION
A file is `IN_PROGRESS` and may have failed due to a transient error. This will allow the file upload to be reattempted at a quieter time.

NO-CARD: Possible Live Defect