### PR TITLE
chore: bump version of reference-client

### DIFF
--- a/generic-upload-service/pom.xml
+++ b/generic-upload-service/pom.xml
@@ -139,7 +139,7 @@
     <dependency>
       <groupId>com.transformuk.hee</groupId>
       <artifactId>reference-client</artifactId>
-      <version>4.12.0</version>
+      <version>4.12.2</version>
     </dependency>
     <dependency>
       <groupId>com.transformuk.hee.tis</groupId>


### PR DESCRIPTION
depends on [TIS-REFERENCE #268](https://github.com/Health-Education-England/TIS-REFERENCE/pull/268)

TIS21-3518