### PR TITLE
build: use OIDC for AWS credentials

### DIFF
--- a/.github/workflows/pr-workflow.yml
+++ b/.github/workflows/pr-workflow.yml
@@ -1,5 +1,9 @@
 name: PR Analysis Workflow
 
+permissions:
+  id-token: write
+  contents: read
+
 on:
   pull_request:
   workflow_dispatch:
@@ -22,9 +26,8 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          aws-access-key-id: ${{ secrets.AWS_MAVEN_USERNAME }}
-          aws-secret-access-key: ${{ secrets.AWS_MAVEN_PASSWORD }}
           aws-region: eu-west-1
+          role-to-assume: arn:aws:iam::430723991443:role/github-actions-deployer-role
 
       - name: Add CodeArtifact env var
         run: echo "CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain hee --domain-owner 430723991443 --query authorizationToken --output text)" >> $GITHUB_ENV
@@ -41,9 +44,8 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: eu-west-2
+          role-to-assume: arn:aws:iam::430723991443:role/github-actions-deployer-role
 
       - name: Run tests
         run: mvn test


### PR DESCRIPTION
Remove the unused ecr and codeartifact user tokens and replace it with a role reference to the github-actions-deployer-role accessible using OIDC.

TIS21-4862