### PR TITLE
fix:rotation mapping in ProgrammeMemebrshipMapper

### DIFF
--- a/generic-upload-service/pom.xml
+++ b/generic-upload-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>generic-upload-service</artifactId>
-  <version>1.20.0</version>
+  <version>1.20.1</version>
 
   <packaging>war</packaging>
 

--- a/generic-upload-service/src/main/java/com/transformuk/hee/tis/genericupload/service/service/mapper/ProgrammeMembershipMapper.java
+++ b/generic-upload-service/src/main/java/com/transformuk/hee/tis/genericupload/service/service/mapper/ProgrammeMembershipMapper.java
@@ -3,18 +3,20 @@ package com.transformuk.hee.tis.genericupload.service.service.mapper;
 import com.transformuk.hee.tis.genericupload.api.dto.ProgrammeMembershipUpdateXls;
 import com.transformuk.hee.tis.genericupload.service.util.DateUtils;
 import com.transformuk.hee.tis.tcs.api.dto.ProgrammeMembershipDTO;
+import com.transformuk.hee.tis.tcs.api.dto.RotationDTO;
 import com.transformuk.hee.tis.tcs.api.enumeration.ProgrammeMembershipType;
 import org.apache.commons.lang3.EnumUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.Named;
 
 @Mapper(componentModel = "spring", uses = {DateUtils.class})
 public interface ProgrammeMembershipMapper {
 
   @Mapping(expression = "java(java.util.UUID.fromString(xls.getProgrammeMembershipId()))",
       target = "uuid")
-  @Mapping(source = "rotation", target = "rotation.name")
+  @Mapping(source = "xls", target = "rotation", qualifiedByName = "setRotation")
   ProgrammeMembershipDTO toDto(ProgrammeMembershipUpdateXls xls);
 
   /**
@@ -31,5 +33,23 @@ public interface ProgrammeMembershipMapper {
       return ProgrammeMembershipType.valueOf(programmeMembershipType);
     }
     return null;
+  }
+
+  /**
+   * Custom method to convert rotation name to Rotation Dto.
+   * Mapstruct does not support: create target nested object only when source field is not null.
+   *
+   * @param xls the programme membership xls to convert
+   * @return the rotation dto
+   */
+  @Named("setRotation")
+  default RotationDTO nameToRotation(ProgrammeMembershipUpdateXls xls) {
+    if (xls == null || xls.getRotation() == null) {
+      return null;
+    }
+
+    RotationDTO rotationDto = new RotationDTO();
+    rotationDto.setName(xls.getRotation());
+    return rotationDto;
   }
 }

--- a/generic-upload-service/src/test/java/com/transformuk/hee/tis/genericupload/service/service/mapper/ProgrammeMembershipMapperTest.java
+++ b/generic-upload-service/src/test/java/com/transformuk/hee/tis/genericupload/service/service/mapper/ProgrammeMembershipMapperTest.java
@@ -81,4 +81,13 @@ public class ProgrammeMembershipMapperTest {
     ProgrammeMembershipDTO programmeMembershipDto = mapper.toDto(xls);
     assertNull(programmeMembershipDto.getProgrammeMembershipType());
   }
+
+  @Test
+  public void shouldSetRotationToNullWhenRotationNameIsNull() {
+    ProgrammeMembershipUpdateXls xls = initialiseXls();
+    xls.setRotation(null);
+
+    ProgrammeMembershipDTO programmeMembershipDto = mapper.toDto(xls);
+    assertNull(programmeMembershipDto.getRotation());
+  }
 }


### PR DESCRIPTION
When no rotation is specified, the nested RotationDTO in ProgrammeMembershipDTO should be null, see this API: https://stage-apps.tis.nhs.uk/tcs/api/trainee/1/programme-memberships/rolled-up

TIS21-3785