### PR TITLE
Feat/require funding for post create tis21 5262

### DIFF
--- a/generic-upload-api/src/main/java/com/transformuk/hee/tis/genericupload/api/dto/PostCreateXls.java
+++ b/generic-upload-api/src/main/java/com/transformuk/hee/tis/genericupload/api/dto/PostCreateXls.java
@@ -48,10 +48,10 @@ public class PostCreateXls extends TemplateXLS {
   @ExcelColumn(name = "Owner*", required = true)
   private String owner;
 
-  @ExcelColumn(name = "Funding Type", required = true)
+  @ExcelColumn(name = "Funding Type*", required = true)
   private String fundingType;
 
-  @ExcelColumn(name = "Funding Start Date", required = true)
+  @ExcelColumn(name = "Funding Start Date*", required = true)
   private Date fundingStartDate;
 
   @ExcelColumn(name = "Funding End Date")


### PR DESCRIPTION
When using an end date, this validates it isn't before the start date.
Elsewhere, the application currently permits `start` > `end` dates.

chore(smells): group test assertions

Creating an expected DTO simplifies the number of asserts.
I think changes in Collections methods are unlikely to break tests.

TIS21-5262: Add Post Funding to Post Create