### PR TITLE
fix:funding subtype validation error message in PostFundingUpdate

### DIFF
--- a/generic-upload-service/pom.xml
+++ b/generic-upload-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>generic-upload-service</artifactId>
-  <version>1.21.1</version>
+  <version>1.21.2</version>
 
   <packaging>war</packaging>
 

--- a/generic-upload-service/src/main/java/com/transformuk/hee/tis/genericupload/service/service/PostFundingUpdateTransformerService.java
+++ b/generic-upload-service/src/main/java/com/transformuk/hee/tis/genericupload/service/service/PostFundingUpdateTransformerService.java
@@ -29,8 +29,8 @@ public class PostFundingUpdateTransformerService {
       "Funding body could not be found for the name \"%s\".";
   protected static final String ERROR_FUNDING_TYPE_IS_REQUIRED_FOR_SUB_TYPE =
       "Funding type is required when funding subtype is filled.";
-  protected static final String ERROR_INVALID_FUNDING_SUB_TYPE_LABEL =
-      "Funding subtype could not be found for the label \"%s\".";
+  protected static final String ERROR_FUNDING_SUB_TYPE_NOT_MATCH_FUNDING_TYPE =
+      "Funding subtype \"%s\" does not match funding type \"%s\".";
 
   @Autowired
   private ReferenceServiceImpl referenceService;
@@ -179,7 +179,8 @@ public class PostFundingUpdateTransformerService {
             ImmutablePair.of(fundingType.toLowerCase(), fundingSubtype.toLowerCase()));
         if (fundingSubtypeId == null) {
           postFundingUpdateXls
-              .addErrorMessage(String.format(ERROR_INVALID_FUNDING_SUB_TYPE_LABEL, fundingSubtype));
+              .addErrorMessage(String.format(ERROR_FUNDING_SUB_TYPE_NOT_MATCH_FUNDING_TYPE,
+                  fundingSubtype, fundingType));
         }
       }
     }

--- a/generic-upload-service/src/test/java/com/transformuk/hee/tis/genericupload/service/service/PostFundingUpdateTransformerServiceTest.java
+++ b/generic-upload-service/src/test/java/com/transformuk/hee/tis/genericupload/service/service/PostFundingUpdateTransformerServiceTest.java
@@ -1,7 +1,7 @@
 package com.transformuk.hee.tis.genericupload.service.service;
 
+import static com.transformuk.hee.tis.genericupload.service.service.PostFundingUpdateTransformerService.ERROR_FUNDING_SUB_TYPE_NOT_MATCH_FUNDING_TYPE;
 import static com.transformuk.hee.tis.genericupload.service.service.PostFundingUpdateTransformerService.ERROR_FUNDING_TYPE_IS_REQUIRED_FOR_SUB_TYPE;
-import static com.transformuk.hee.tis.genericupload.service.service.PostFundingUpdateTransformerService.ERROR_INVALID_FUNDING_SUB_TYPE_LABEL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -36,7 +36,7 @@ class PostFundingUpdateTransformerServiceTest {
   private static final UUID FUNDING_SUBTYPE_UUID = UUID.randomUUID();
   private static final String FUNDING_SUBTYPE_LABEL = "fundingSubtype";
   private static final String ERROR_INVALID_FUNDING_SUB_TYPE = String.format(
-      ERROR_INVALID_FUNDING_SUB_TYPE_LABEL, FUNDING_SUBTYPE_LABEL);
+      ERROR_FUNDING_SUB_TYPE_NOT_MATCH_FUNDING_TYPE, FUNDING_SUBTYPE_LABEL, FUNDING_TYPE_LABEL);
   private FundingTypeDTO fundingTypeDto;
   private FundingSubTypeDto fundingSubTypeDto;
 


### PR DESCRIPTION
An admin user thought the current error message "" was a bit confusing.

> I wonder if it’s a little confusing where it is a valid subtype, but it’s just been put against an incorrect funding type? For instance, ‘Supernumerary’ funding and ‘Community Setting’ subtype do not match up on the table, but instead of the error message signalling that it just says that ‘Community Setting’ could not be found.

TIS21-5383