### PR TITLE
chore: revert java version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@ node {
     }
 
     env.GIT_COMMIT=sh(returnStdout: true, script: "git log -n 1 --pretty=format:'%h'").trim()
-    def mvn = "${tool 'Maven 3.9.8'}/bin/mvn"
+    def mvn = "${tool 'Maven 3.3.9'}/bin/mvn"
     def workspace = pwd()
     def parent_workspace = pwd()
     def repository = "${env.GIT_COMMIT}".split("TIS-")[-1].split(".git")[0]

--- a/generic-upload-service/pom.xml
+++ b/generic-upload-service/pom.xml
@@ -28,7 +28,7 @@
     <frontend-maven-plugin.version>1.6</frontend-maven-plugin.version>
     <hibernate.version>5.3.34.Final</hibernate.version>
     <hibernate.validator.version>5.3.6.Final</hibernate.validator.version>
-    <java.version>11</java.version>
+    <java.version>1.8</java.version>
     <jjwt.version>0.9.1</jjwt.version>
     <m2e.apt.activation>jdt_apt</m2e.apt.activation>
     <mapstruct.version>1.4.2.Final</mapstruct.version>


### PR DESCRIPTION
This revert is done to avoid the following error message during stage deployment.
`generic-upload_1  | Exception in thread "main" java.lang.UnsupportedClassVersionError: com/transformuk/hee/tis/genericupload/service/Application has been compiled by a more recent version of the Java Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0`

There will be a ticket soon to address this tech debt.

Please note that Generic upload Sonar cloud checking failure is acceptable for now, as it is considering all the old code to calculate the percentage.