### PR TITLE
fix: use compatible profile client

### DIFF
--- a/generic-upload-service/pom.xml
+++ b/generic-upload-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>generic-upload-service</artifactId>
-  <version>1.28.0</version>
+  <version>1.28.1</version>
 
   <packaging>war</packaging>
 
@@ -116,7 +116,7 @@
     <dependency>
       <groupId>com.transformuk.hee</groupId>
       <artifactId>profile-client</artifactId>
-      <version>3.3.0</version>
+      <version>3.1.1</version>
     </dependency>
     <dependency>
       <groupId>com.transformuk.hee.tis</groupId>


### PR DESCRIPTION
This quickly restores service for the stage/test environment. The `profile-client` v3.2+ is built on Java 11.
We will be migrating generic upload to a later version of java. The runtime JRE is derived from a custom base image. There is an unknown amount of work to upgrade the docker image.

TIS21-7129: Use Person ID to create a placement against