### PR TITLE
feat: add docker file

### DIFF
--- a/generic-upload-service/Dockerfile
+++ b/generic-upload-service/Dockerfile
@@ -1,0 +1,7 @@
+FROM eclipse-temurin:11-alpine
+
+EXPOSE 8099
+
+COPY target/app.jar app.jar
+
+CMD ["java", "-XX:MaxRAMPercentage=95.0", "-jar", "app.jar"]


### PR DESCRIPTION
It was my mistake I forgot to add the Dockerfile to the generic-upload-service folder and that is the reason the work flow was failing and giving the following error.
```

#1 [internal] load build definition from Dockerfile
#1 transferring dockerfile: 2B done
#1 DONE 0.0s
ERROR: failed to build: failed to solve: failed to read dockerfile: open Dockerfile: no such file or directory
Error: Process completed with exit code 1.
```
TIS21-7193