### PR TITLE
chore: add placeholder azure values

### DIFF
--- a/.aws/tis-generic-upload-preprod.json
+++ b/.aws/tis-generic-upload-preprod.json
@@ -136,6 +136,42 @@
         {
           "name": "PROFILE_JWT_CACHE_TTL",
           "value": "10"
+        },
+        {
+          "name": "CLOUD_BLOB_ACCOUNT_NAME",
+          "value": "dummy"
+        },
+        {
+          "name": "CLOUD_BLOB_ACCOUNT_KEY",
+          "value": "dummy"
+        },
+        {
+          "name": "CLOUD_BLOB_CONTAINER_NAME",
+          "value": "fileupload"
+        },
+        {
+          "name": "SERVICE_BUS_CONNECTION_STRING",
+          "value": "dummy"
+        },
+        {
+          "name": "SERVICE_BUS_QUEUE_NAME",
+          "value": "dummy"
+        },
+        {
+          "name": "SERVICE_BUS_Q_RECEIVE_MODE",
+          "value": "dummy"
+        },
+        {
+          "name": "SERVICE_BUS_TOPIC_NAME",
+          "value": "dummy"
+        },
+        {
+          "name": "SERVICE_BUS_SUBSCRIPTION_NAME",
+          "value": "dummy"
+        },
+        {
+          "name": "SERVICE_BUS_S_RECEIVE_MODE",
+          "value": "peeklock"
         }
       ]
     }


### PR DESCRIPTION
We have the following Azure Blob storage properties in the yml file

```
azure:
  accountName: ${CLOUD_BLOB_ACCOUNT_NAME}
  accountKey: ${CLOUD_BLOB_ACCOUNT_KEY}
  containerName: ${CLOUD_BLOB_CONTAINER_NAME}
  servicebus:
    connection-string: ${SERVICE_BUS_CONNECTION_STRING}
    queue-name: ${SERVICE_BUS_QUEUE_NAME}
    queue-receive-mode: ${SERVICE_BUS_Q_RECEIVE_MODE}
    topic-name: ${SERVICE_BUS_TOPIC_NAME}
    subscription-name: ${SERVICE_BUS_SUBSCRIPTION_NAME}
    subscription-receive-mode: ${SERVICE_BUS_S_RECEIVE_MODE}
```

We are not using Azure any more. We are using AWS and it is also not possible to remove these Azure variable due to the Bean creation.
We are deploying the service in AWS ECS and the deployment fails by showing the following error

```
Caused by: java.lang.IllegalStateException: Error processing condition on com.microsoft.azure.spring.autoconfigure.servicebus.ServiceBusAutoConfiguration
	at org.springframework.boot.autoconfigure.condition.SpringBootCondition.matches(SpringBootCondition.java:60)
	at org.springframework.context.annotation.ConditionEvaluator.shouldSkip(ConditionEvaluator.java:108)
	at org.springframework.context.annotation.ConfigurationClassParser.processConfigurationClass(ConfigurationClassParser.java:225)
	at org.springframework.context.annotation.ConfigurationClassParser.processImports(ConfigurationClassParser.java:599)
	... 25 common frames omitted
Caused by: java.lang.IllegalArgumentException: Could not resolve placeholder 'SERVICE_BUS_CONNECTION_STRING' in value "${SERVICE_BUS_CONNECTION_STRING}"
	at org.springframework.util.PropertyPlaceholderHelper.parseStringValue(PropertyPlaceholderHelper.java:180)
```