### PR TITLE
fix: use correct enum value for azure service mode name

### DIFF
--- a/.aws/tis-generic-upload-preprod.json
+++ b/.aws/tis-generic-upload-preprod.json
@@ -159,7 +159,7 @@
         },
         {
           "name": "SERVICE_BUS_Q_RECEIVE_MODE",
-          "value": "PEEKLOCK"
+          "value": "peeklock"
         },
         {
           "name": "SERVICE_BUS_TOPIC_NAME",
@@ -171,7 +171,7 @@
         },
         {
           "name": "SERVICE_BUS_S_RECEIVE_MODE",
-          "value": "PEEKLOCK"
+          "value": "peeklock"
         }
       ]
     }


### PR DESCRIPTION
Used SERVICE_BUS_Q_RECEIVE_MODE value as `PEEKLOCK` to prevent the following error:
`
 Error creating bean with name 'azure.servicebus-com.microsoft.azure.spring.autoconfigure.servicebus.ServiceBusProperties': Could not bind properties to 'ServiceBusProperties' : prefix=azure.servicebus, ignoreInvalidFields=false, ignoreUnknownFields=true; nested exception is org.springframework.boot.context.properties.bind.BindException: Failed to bind properties under 'azure.servicebus.queue-receive-mode' to com.microsoft.azure.servicebus.ReceiveMode`

```
Update your application's configuration. The following values are valid:
    PEEKLOCK
    RECEIVEANDDELETE
```
   


