### PR TITLE
feat: add aws creds accessing s3

### DIFF
--- a/.aws/tis-generic-upload-preprod.json
+++ b/.aws/tis-generic-upload-preprod.json
@@ -54,6 +54,14 @@
           "valueFrom": "/tis/generic-upload/preprod/s3/bucket-name"
         },
         {
+          "name": "AWS_ACCESS_KEY_ID",
+          "valueFrom": "/tis/generic-upload/preprod/s3/access-key-id"
+        },
+        {
+          "name": "AWS_SECRET_ACCESS_KEY",
+          "valueFrom": "/tis/generic-upload/preprod/s3/secret-access-key"
+        },
+        {
           "name": "DEADLETER_DIR",
           "valueFrom": "/tis/generic-upload/preprod/deadletter/dir"
         },


### PR DESCRIPTION
To avoid the following error the AWS creds are needed
`software.amazon.awssdk.core.exception.SdkClientException: Unable to load credentials from any of the providers in the chain AwsCredentialsProviderChain(credentialsProviders=[SystemPropertyCredentialsProvider(), EnvironmentVariableCredentialsProvider(), WebIdentityTokenCredentialsProvider(), ProfileCredentialsProvider(), ContainerCredentialsProvider(), InstanceProfileCredentialsProvider()]) : [SystemPropertyCredentialsProvider(): Unable to load credentials from system settings. Access key must be specified either via environment variable (AWS_ACCESS_KEY_ID) or system property (aws.accessKeyId)., EnvironmentVariableCredentialsProvider(): Unable to load credentials from system settings. Access key must be specified either via environment variable (AWS_ACCESS_KEY_ID) or system property (aws.accessKeyId)., WebIdentityTokenCredentialsProvider(): Either the environment variable AWS_WEB_IDENTITY_TOKEN_FILE or the javaproperty aws.webIdentityTokenFile must be set`