### PR TITLE
chore: update the status of a stalled file to UNEXPECTED_ERROR

### DIFF
--- a/generic-upload-service/src/main/resources/db/migration/V1.12__update_stalled_file4.sql
+++ b/generic-upload-service/src/main/resources/db/migration/V1.12__update_stalled_file4.sql
@@ -1,0 +1,7 @@
+-- Set stalled file to ERROR
+UPDATE `ApplicationType`
+SET `status` = 'UNEXPECTED_ERROR'
+WHERE `id` IN(46483)
+  AND `logId` IN(1758710940483)
+  AND `fileName` = 'NHS Email update.xls'
+  AND `status` = 'IN_PROGRESS';


### PR DESCRIPTION
A bulk upload user spotted the uploads had been stalled for a few hours:  [Teams TIS Support Channel - General](https://teams.microsoft.com/l/message/19:PRNrRvpg8X0ir9ozsR68_-v7yuLNfK65TwHUTy_br9Q1@thread.tacv2/1758721538693?tenantId=37c354b2-85b0-47f5-b222-07b48d774ee3&groupId=52fd02e0-5141-4c59-9dfe-aab03d557f5a&parentMessageId=1758721538693&teamName=TIS%20Support%20Channel&channelName=General&createdTime=1758721538693)

TIS_SHED