### PR TITLE
fix: trim person ID on person update upload

### DIFF
--- a/generic-upload-service/pom.xml
+++ b/generic-upload-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>generic-upload-service</artifactId>
-  <version>1.29.2</version>
+  <version>1.29.3</version>
 
   <packaging>war</packaging>
 

--- a/generic-upload-service/src/main/java/com/transformuk/hee/tis/genericupload/service/service/PersonUpdateTransformerService.java
+++ b/generic-upload-service/src/main/java/com/transformuk/hee/tis/genericupload/service/service/PersonUpdateTransformerService.java
@@ -40,6 +40,7 @@ public class PersonUpdateTransformerService {
 
   public void processUpload(List<PersonUpdateXls> xlsList) {
     xlsList.forEach(TemplateXLS::initialiseSuccessfullyImported);
+    xlsList.forEach(update -> update.setTisPersonId(update.getTisPersonId().trim()));
 
     Map<Long, PersonUpdateXls> personIdToXls = new HashMap<>();
     List<PersonDTO> personDtos = new ArrayList<>();
@@ -114,9 +115,6 @@ public class PersonUpdateTransformerService {
   private void initialValidate(PersonUpdateXls xls) {
 
     List<String> errorMessages = new ArrayList<>();
-
-    String trimmedId = xls.getTisPersonId().trim();
-    xls.setTisPersonId(trimmedId);
 
     String trainerApprovalStatus = xls.getTrainerApprovalStatus();
     if (!StringUtils.isEmpty(trainerApprovalStatus) && !EnumUtils.isValidEnum(

--- a/generic-upload-service/src/main/java/com/transformuk/hee/tis/genericupload/service/service/PersonUpdateTransformerService.java
+++ b/generic-upload-service/src/main/java/com/transformuk/hee/tis/genericupload/service/service/PersonUpdateTransformerService.java
@@ -115,6 +115,9 @@ public class PersonUpdateTransformerService {
 
     List<String> errorMessages = new ArrayList<>();
 
+    String trimmedId = xls.getTisPersonId().trim();
+    xls.setTisPersonId(trimmedId);
+
     String trainerApprovalStatus = xls.getTrainerApprovalStatus();
     if (!StringUtils.isEmpty(trainerApprovalStatus) && !EnumUtils.isValidEnum(
         ApprovalStatus.class, trainerApprovalStatus)) {

--- a/generic-upload-service/src/test/java/com/transformuk/hee/tis/genericupload/service/service/PersonUpdateTransformServiceTest.java
+++ b/generic-upload-service/src/test/java/com/transformuk/hee/tis/genericupload/service/service/PersonUpdateTransformServiceTest.java
@@ -178,7 +178,7 @@ public class PersonUpdateTransformServiceTest {
     PersonUpdateXls xls1 = new PersonUpdateXls();
     xls1.setTisPersonId(nbspId);
 
-    String spaceId = "    1111111";
+    String spaceId = "1111 111";
     PersonUpdateXls xls2 = new PersonUpdateXls();
     xls2.setTisPersonId(spaceId);
 
@@ -202,5 +202,26 @@ public class PersonUpdateTransformServiceTest {
 
     verify(personMapperMock, never()).toDto(any());
     verify(tcsServiceImplMock, never()).patchPeople(any());
+  }
+
+  @Test
+  public void shouldNotReturnErrorMessageWhenTrimmedIdIsValid() {
+    PersonUpdateXls xls = new PersonUpdateXls();
+    xls.setTisPersonId(" 1111111  ");
+    xls.setRole("role");
+
+    PersonDTO personDto = new PersonDTO();
+    personDto.setId(1111111L);
+    personDto.setRole(xls.getRole());
+
+    TrainerApprovalDTO taDto = new TrainerApprovalDTO();
+    taDto.setPerson(personDto);
+    taDto.setApprovalStatus(ApprovalStatus.CURRENT);
+
+    when(personMapperMock.toDto(xls)).thenReturn(personDto);
+    when(trainerApprovalMapper.toDto(xls)).thenReturn(taDto);
+
+    personUpdateTransformerService.processUpload(List.of(xls));
+    assertNull(xls.getErrorMessage());
   }
 }


### PR DESCRIPTION
TIS21-4913: Whole bulk person update file fails if 1 ID has a non-breaking space