### PR TITLE
Feat/validate required funding subtypes on funding update tis21 8840

### DIFF
--- a/.github/workflows/ci-cd-workflow.yml
+++ b/.github/workflows/ci-cd-workflow.yml
@@ -63,7 +63,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
 
       - name: Add Maven HEE Repo
         uses: whelk-io/maven-settings-xml-action@v22

--- a/.github/workflows/pr-workflow.yml
+++ b/.github/workflows/pr-workflow.yml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
 
       - name: Add Maven HEE Repo
         uses: whelk-io/maven-settings-xml-action@v22

--- a/.github/workflows/pr-workflow.yml
+++ b/.github/workflows/pr-workflow.yml
@@ -66,4 +66,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn sonar:sonar
+        run: mvn org.sonarsource.scanner.maven:sonar-maven-plugin:sonar

--- a/generic-upload-service/pom.xml
+++ b/generic-upload-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>generic-upload-service</artifactId>
-  <version>1.29.3</version>
+  <version>1.30.0</version>
 
   <packaging>war</packaging>
 

--- a/generic-upload-service/src/main/java/com/transformuk/hee/tis/genericupload/service/service/PostFundingUpdateTransformerService.java
+++ b/generic-upload-service/src/main/java/com/transformuk/hee/tis/genericupload/service/service/PostFundingUpdateTransformerService.java
@@ -9,17 +9,22 @@ import com.transformuk.hee.tis.reference.client.impl.ReferenceServiceImpl;
 import com.transformuk.hee.tis.tcs.api.dto.PostDTO;
 import com.transformuk.hee.tis.tcs.api.dto.PostFundingDTO;
 import com.transformuk.hee.tis.tcs.client.service.impl.TcsServiceImpl;
+import java.time.Clock;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -39,9 +44,13 @@ public class PostFundingUpdateTransformerService {
       "Post funding start date cannot be null or empty";
   protected static final String FUNDING_END_DATE_VALIDATION_MSG =
       "Post funding end date must not be equal to or before start date if included.";
+  protected static final String FUNDING_TYPE_REQUIRES_SUBTYPE =
+      "One of the appropriate funding subtypes must be included for this type of funding.";
   protected static final String ERROR_INVALID_FUNDING_REASON =
       "Funding reason could not be found for the name \"%s\".";
-  private Map<String, UUID> fundingReasonToIdMap = new HashMap<>();
+
+  private final Map<String, UUID> fundingReasonToIdMap = new HashMap<>();
+  private Clock clock = Clock.systemDefaultZone();
 
   @Autowired
   private ReferenceServiceImpl referenceService;
@@ -49,27 +58,38 @@ public class PostFundingUpdateTransformerService {
   private TcsServiceImpl tcsService;
 
   public void processPostFundingUpdateUpload(List<PostFundingUpdateXLS> postFundingUpdateXlss) {
-    postFundingUpdateXlss.forEach(PostFundingUpdateXLS::initialiseSuccessfullyImported);
+    Set<String> fundingBodies = new HashSet<>();
+    Set<String> fundingSubTypeLabels = new HashSet<>();
+    Set<String> fundingTypeLabels = new HashSet<>();
+    postFundingUpdateXlss.forEach(xls -> {
+      xls.initialiseSuccessfullyImported();
+      fundingBodies.add(xls.getFundingBody());
+      fundingTypeLabels.add(xls.getFundingType());
+      fundingSubTypeLabels.add(xls.getFundingSubtype());
+    });
 
     // Get all funding bodies and retrieve matching funding body IDs.
-    Set<String> fundingBodies = postFundingUpdateXlss.stream()
-        .map(PostFundingUpdateXLS::getFundingBody).collect(Collectors.toSet());
-    List<TrustDTO> trusts = referenceService.findCurrentTrustsByTrustKnownAsIn(fundingBodies);
-    Map<String, String> fundingBodyNameToId = trusts.stream()
+    Map<String, String> fundingBodyNameToId = referenceService
+        .findCurrentTrustsByTrustKnownAsIn(fundingBodies).stream()
         .collect(Collectors.toMap(TrustDTO::getTrustKnownAs, dto -> String.valueOf(dto.getId())));
 
+    Map<String, List<FundingSubTypeDto>> fundingTypeToSubtypes =
+        new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+    referenceService
+        .findCurrentFundingTypesByLabelIn(fundingTypeLabels).forEach(t -> {
+          List<FundingSubTypeDto> subtypes =
+              referenceService.findCurrentFundingSubTypesForFundingTypeId(t.getId());
+          fundingTypeToSubtypes.put(t.getLabel(), subtypes);
+        });
     // Get all fundingSubType and retrieve matching fundingSubType IDs.
-    Set<String> fundingSubTypeLabels = postFundingUpdateXlss.stream()
-        .map(PostFundingUpdateXLS::getFundingSubtype).collect(Collectors.toSet());
-    List<FundingSubTypeDto> fundingSubTypes =
-        referenceService.findCurrentFundingSubTypesByLabels(fundingSubTypeLabels);
     // As fundingSubtype label is not unique for all fundingSubtypes,
     // use (fundingType label, fundingSubtype label) from reference service as key.
-    Map<ImmutablePair<String, String>, UUID> fundingSubTypeLabelToId = fundingSubTypes.stream()
-        .collect(Collectors.toMap(
-            dto -> ImmutablePair.of(dto.getFundingType().getLabel().toLowerCase(),
-                dto.getLabel().toLowerCase()),
-            FundingSubTypeDto::getId));
+    Map<ImmutablePair<String, String>, UUID> fundingSubTypeLabelToId =
+        referenceService.findCurrentFundingSubTypesByLabels(fundingSubTypeLabels).stream()
+            .collect(Collectors.toMap(
+                dto -> ImmutablePair.of(dto.getFundingType().getLabel().toLowerCase(),
+                    dto.getLabel().toLowerCase()),
+                FundingSubTypeDto::getId));
 
     // Get all funding reasons and retrieve matching funding body IDs.
     postFundingUpdateXlss.stream()
@@ -98,13 +118,13 @@ public class PostFundingUpdateTransformerService {
       }
     }
 
-    for (Entry<String, List<PostFundingUpdateXLS>> postIdToPostFundingUpdateXls : postIdsToPostFundingUpdateXls
-        .entrySet()) {
+    for (Entry<String, List<PostFundingUpdateXLS>> postIdToPostFundingUpdateXls :
+        postIdsToPostFundingUpdateXls.entrySet()) {
       String postId = postIdToPostFundingUpdateXls.getKey();
 
       Map<PostFundingDTO, PostFundingUpdateXLS> fundingDtosToSource = buildFundingDtos(
           postIdToPostFundingUpdateXls.getValue(), fundingBodyNameToId, fundingSubTypeLabelToId,
-          fundingReasonToIdMap);
+          fundingTypeToSubtypes, fundingReasonToIdMap);
       Set<PostFundingDTO> builtPostFundingDtos = fundingDtosToSource.keySet();
       if (builtPostFundingDtos.isEmpty()) {
         continue;
@@ -150,6 +170,7 @@ public class PostFundingUpdateTransformerService {
       Collection<PostFundingUpdateXLS> postFundingUpdateXlss,
       Map<String, String> fundingBodyNameToId,
       Map<ImmutablePair<String, String>, UUID> fundingSubTypeLabelToId,
+      Map<String, List<FundingSubTypeDto>> fundingTypeToSubtypes,
       Map<String, UUID> fundingReasonToIdMap) {
     Map<PostFundingDTO, PostFundingUpdateXLS> postFundingDtosToSource = new HashMap<>();
 
@@ -162,12 +183,29 @@ public class PostFundingUpdateTransformerService {
             .addErrorMessage(String.format(ERROR_INVALID_FUNDING_BODY_NAME, fundingBodyName));
       }
 
+      final String fundingType = postFundingUpdateXls.getFundingType();
       final UUID fundingSubTypeId = checkAndGetFundingSubtype(postFundingUpdateXls,
           fundingSubTypeLabelToId);
+      boolean expired = postFundingUpdateXls.getDateTo() != null
+          && postFundingUpdateXls.getDateTo().before(Date.from(clock.instant()));
+      /*
+      Rather than using "FundingStatus = CURRENT", the requirement is a subtype is required when:
+      - The funding has not expired (i.e. the end date is null or no earlier than today)
+      - A funding type has been provided
+      - A funding subtype has not been provided
+      - The funding type has subtypes (i.e. the list of subtypes for the funding type is not empty)
+        - A non-existent funding type is treated as having no subtypes
+       */
+      if (!expired
+          && StringUtils.isNotBlank(fundingType)
+          && fundingSubTypeId == null
+          && CollectionUtils.isNotEmpty(fundingTypeToSubtypes.get(fundingType))) {
+        postFundingUpdateXls.addErrorMessage(FUNDING_TYPE_REQUIRES_SUBTYPE);
+      }
+
       if (StringUtils.isNotEmpty(postFundingUpdateXls.getErrorMessage())) {
         continue;
       }
-
       PostFundingDTO postFundingDto = new PostFundingDTO();
       postFundingDto.setFundingType(postFundingUpdateXls.getFundingType());
       postFundingDto.setInfo(postFundingUpdateXls.getFundingTypeOther());
@@ -190,8 +228,8 @@ public class PostFundingUpdateTransformerService {
     String fundingSubtype = postFundingUpdateXls.getFundingSubtype();
     UUID fundingSubtypeId = null;
 
-    if (fundingSubtype != null) {
-      if (fundingType == null) {
+    if (StringUtils.isNotBlank(fundingSubtype)) {
+      if (StringUtils.isBlank(fundingType)) {
         postFundingUpdateXls
             .addErrorMessage(ERROR_FUNDING_TYPE_IS_REQUIRED_FOR_SUB_TYPE);
       } else {
@@ -244,5 +282,9 @@ public class PostFundingUpdateTransformerService {
       referenceService.findCurrentFundingReasonsByReasonIn(Collections.singleton(fundingReason))
           .forEach(dto -> fundingReasonToIdMap.put(dto.getReason(), dto.getId()));
     }
+  }
+
+  public void setClock(Clock clock) {
+    this.clock = clock;
   }
 }

--- a/generic-upload-service/src/main/java/com/transformuk/hee/tis/genericupload/service/service/PostFundingUpdateTransformerService.java
+++ b/generic-upload-service/src/main/java/com/transformuk/hee/tis/genericupload/service/service/PostFundingUpdateTransformerService.java
@@ -14,7 +14,6 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -28,10 +27,10 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClientException;
 
-@Component
+@Service
 public class PostFundingUpdateTransformerService {
 
   protected static final String ERROR_INVALID_FUNDING_BODY_NAME =

--- a/generic-upload-service/src/main/java/com/transformuk/hee/tis/genericupload/service/service/PostFundingUpdateTransformerService.java
+++ b/generic-upload-service/src/main/java/com/transformuk/hee/tis/genericupload/service/service/PostFundingUpdateTransformerService.java
@@ -187,7 +187,8 @@ public class PostFundingUpdateTransformerService {
       final UUID fundingSubTypeId = checkAndGetFundingSubtype(postFundingUpdateXls,
           fundingSubTypeLabelToId);
       boolean expired = postFundingUpdateXls.getDateTo() != null
-          && postFundingUpdateXls.getDateTo().before(Date.from(clock.instant()));
+          && postFundingUpdateXls.getDateTo().toInstant().atZone(clock.getZone()).toLocalDate()
+          .isBefore(LocalDate.now(clock));
       /*
       Rather than using "FundingStatus = CURRENT", the requirement is a subtype is required when:
       - The funding has not expired (i.e. the end date is null or no earlier than today)
@@ -284,7 +285,7 @@ public class PostFundingUpdateTransformerService {
     }
   }
 
-  public void setClock(Clock clock) {
+  void setClock(Clock clock) {
     this.clock = clock;
   }
 }

--- a/generic-upload-service/src/test/java/com/transformuk/hee/tis/genericupload/service/service/PostFundingUpdateTransformerServiceTest.java
+++ b/generic-upload-service/src/test/java/com/transformuk/hee/tis/genericupload/service/service/PostFundingUpdateTransformerServiceTest.java
@@ -51,6 +51,8 @@ class PostFundingUpdateTransformerServiceTest {
   private static final UUID FUNDING_REASON_UUID = UUID.randomUUID();
   private static final String ERROR_INVALID_FUNDING_SUB_TYPE = String.format(
       ERROR_FUNDING_SUB_TYPE_NOT_MATCH_FUNDING_TYPE, FUNDING_SUBTYPE_LABEL, FUNDING_TYPE_LABEL);
+  private static final Clock CLOCK =
+      Clock.fixed(Instant.parse("2025-08-16T00:05:01Z"), ZoneOffset.UTC);
   private FundingTypeDTO fundingTypeDto;
   private FundingSubTypeDto fundingSubTypeDto;
 
@@ -86,7 +88,7 @@ class PostFundingUpdateTransformerServiceTest {
     fundingReasonDto.setId(FUNDING_REASON_UUID);
     fundingReasonDto.setReason(FUNDING_REASON);
 
-    uploadService.setClock(Clock.fixed(Instant.parse("2025-08-16T00:00:00Z"), ZoneOffset.UTC));
+    uploadService.setClock(CLOCK);
   }
 
   @Test
@@ -239,6 +241,7 @@ class PostFundingUpdateTransformerServiceTest {
     when(postFundingUpdateXls.getFundingType()).thenReturn(FUNDING_TYPE_LABEL);
     when(postFundingUpdateXls.getFundingSubtype()).thenReturn(null);
     when(postFundingUpdateXls.getErrorMessage()).thenReturn(FUNDING_TYPE_REQUIRES_SUBTYPE);
+    when(postFundingUpdateXls.getDateTo()).thenReturn(Date.from(CLOCK.instant().minusSeconds(40)));
 
     when(referenceServiceMock.findCurrentFundingTypesByLabelIn(
         Collections.singleton(FUNDING_TYPE_LABEL)))

--- a/generic-upload-service/src/test/java/com/transformuk/hee/tis/genericupload/service/service/PostFundingUpdateTransformerServiceTest.java
+++ b/generic-upload-service/src/test/java/com/transformuk/hee/tis/genericupload/service/service/PostFundingUpdateTransformerServiceTest.java
@@ -4,11 +4,12 @@ import static com.transformuk.hee.tis.genericupload.service.config.MapperConfigu
 import static com.transformuk.hee.tis.genericupload.service.service.PostFundingUpdateTransformerService.ERROR_FUNDING_SUB_TYPE_NOT_MATCH_FUNDING_TYPE;
 import static com.transformuk.hee.tis.genericupload.service.service.PostFundingUpdateTransformerService.ERROR_FUNDING_TYPE_IS_REQUIRED_FOR_SUB_TYPE;
 import static com.transformuk.hee.tis.genericupload.service.service.PostFundingUpdateTransformerService.ERROR_INVALID_FUNDING_REASON;
+import static com.transformuk.hee.tis.genericupload.service.service.PostFundingUpdateTransformerService.FUNDING_TYPE_REQUIRES_SUBTYPE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -20,9 +21,13 @@ import com.transformuk.hee.tis.reference.client.impl.ReferenceServiceImpl;
 import com.transformuk.hee.tis.tcs.api.dto.PostDTO;
 import com.transformuk.hee.tis.tcs.api.dto.PostFundingDTO;
 import com.transformuk.hee.tis.tcs.client.service.impl.TcsServiceImpl;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
+import java.util.Set;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -80,6 +85,8 @@ class PostFundingUpdateTransformerServiceTest {
     fundingReasonDto = new FundingReasonDto();
     fundingReasonDto.setId(FUNDING_REASON_UUID);
     fundingReasonDto.setReason(FUNDING_REASON);
+
+    uploadService.setClock(Clock.fixed(Instant.parse("2025-08-16T00:00:00Z"), ZoneOffset.UTC));
   }
 
   @Test
@@ -104,7 +111,7 @@ class PostFundingUpdateTransformerServiceTest {
     PostDTO postDto = postDtoCaptor.getValue();
     assertEquals(1, postDto.getFundings().size());
     PostFundingDTO postFundingDto = postDto.getFundings().iterator().next();
-    assertEquals(postFundingDto.getFundingSubTypeId(), FUNDING_SUBTYPE_UUID);
+    assertEquals(FUNDING_SUBTYPE_UUID, postFundingDto.getFundingSubTypeId());
   }
 
   @Test
@@ -133,7 +140,7 @@ class PostFundingUpdateTransformerServiceTest {
     verify(postFundingUpdateXls, never()).addErrorMessage(anyString());
     PostDTO postDto = postDtoCaptor.getValue();
     PostFundingDTO postFundingDto = postDto.getFundings().iterator().next();
-    assertEquals(postFundingDto.getFundingReasonId(), FUNDING_REASON_UUID);
+    assertEquals(FUNDING_REASON_UUID, postFundingDto.getFundingReasonId());
   }
 
   @Test
@@ -163,7 +170,7 @@ class PostFundingUpdateTransformerServiceTest {
         String.format(ERROR_INVALID_FUNDING_REASON, INVALID_FUNDING_REASON));
     PostDTO postDto = postDtoCaptor.getValue();
     PostFundingDTO postFundingDto = postDto.getFundings().iterator().next();
-    assertEquals(postFundingDto.getFundingReasonId(), null);
+    assertNull(postFundingDto.getFundingReasonId());
   }
 
   @Test
@@ -189,7 +196,7 @@ class PostFundingUpdateTransformerServiceTest {
     PostDTO postDto = postDtoCaptor.getValue();
     assertEquals(1, postDto.getFundings().size());
     PostFundingDTO postFundingDto = postDto.getFundings().iterator().next();
-    assertEquals(postFundingDto.getFundingSubTypeId(), FUNDING_SUBTYPE_UUID);
+    assertEquals(FUNDING_SUBTYPE_UUID, postFundingDto.getFundingSubTypeId());
   }
 
   @Test
@@ -228,6 +235,76 @@ class PostFundingUpdateTransformerServiceTest {
   }
 
   @Test
+  void shouldAddErrorWhenFundingTypeRequiresSubtypeButSubtypeMissing() {
+    when(postFundingUpdateXls.getFundingType()).thenReturn(FUNDING_TYPE_LABEL);
+    when(postFundingUpdateXls.getFundingSubtype()).thenReturn(null);
+    when(postFundingUpdateXls.getErrorMessage()).thenReturn(FUNDING_TYPE_REQUIRES_SUBTYPE);
+
+    when(referenceServiceMock.findCurrentFundingTypesByLabelIn(
+        Collections.singleton(FUNDING_TYPE_LABEL)))
+        .thenReturn(Collections.singletonList(fundingTypeDto));
+    when(referenceServiceMock.findCurrentFundingSubTypesForFundingTypeId(FUNDING_TYPE_ID))
+        .thenReturn(Collections.singletonList(fundingSubTypeDto));
+
+    uploadService.processPostFundingUpdateUpload(Collections.singletonList(postFundingUpdateXls));
+
+    verify(tcsServiceMock, never()).updatePostFundings(any());
+    verify(postFundingUpdateXls).addErrorMessage(FUNDING_TYPE_REQUIRES_SUBTYPE);
+  }
+
+  @Test
+  void shouldUpdateWhenFundingTypeDoesNotRequireSubtype() {
+    when(postFundingUpdateXls.getFundingType()).thenReturn(FUNDING_TYPE_LABEL);
+    when(postFundingUpdateXls.getFundingSubtype()).thenReturn(null);
+
+    Calendar calendar = Calendar.getInstance();
+    calendar.set(2023, Calendar.JANUARY, 2);
+    when(postFundingUpdateXls.getDateFrom()).thenReturn(calendar.getTime());
+
+    when(referenceServiceMock.findCurrentFundingTypesByLabelIn(
+        Collections.singleton(FUNDING_TYPE_LABEL)))
+        .thenReturn(Collections.singletonList(fundingTypeDto));
+    when(referenceServiceMock.findCurrentFundingSubTypesForFundingTypeId(FUNDING_TYPE_ID))
+        .thenReturn(Collections.emptyList());
+
+    uploadService.processPostFundingUpdateUpload(Collections.singletonList(postFundingUpdateXls));
+
+    verify(tcsServiceMock).updatePostFundings(postDtoCaptor.capture());
+    verify(postFundingUpdateXls, never()).addErrorMessage(FUNDING_TYPE_REQUIRES_SUBTYPE);
+    Set<PostFundingDTO> fundings = postDtoCaptor.getValue().getFundings();
+    assertEquals(1, fundings.size());
+    fundings.forEach(funding -> {
+      assertEquals(FUNDING_TYPE_LABEL, funding.getFundingType());
+      assertNull(funding.getFundingSubTypeId());
+    });
+  }
+
+  @Test
+  void shouldUpdateWhenEndedAndSubtypeMissing() {
+    when(postFundingUpdateXls.getFundingType()).thenReturn(FUNDING_TYPE_LABEL);
+    Calendar calendar = Calendar.getInstance();
+    calendar.set(2023, Calendar.JANUARY, 2);
+    when(postFundingUpdateXls.getDateTo()).thenReturn(calendar.getTime());
+
+    when(referenceServiceMock.findCurrentFundingTypesByLabelIn(
+        Collections.singleton(FUNDING_TYPE_LABEL)))
+        .thenReturn(Collections.singletonList(fundingTypeDto));
+    when(referenceServiceMock.findCurrentFundingSubTypesForFundingTypeId(FUNDING_TYPE_ID))
+        .thenReturn(Collections.singletonList(fundingSubTypeDto));
+
+    uploadService.processPostFundingUpdateUpload(Collections.singletonList(postFundingUpdateXls));
+
+    verify(tcsServiceMock).updatePostFundings(postDtoCaptor.capture());
+    verify(postFundingUpdateXls, never()).addErrorMessage(FUNDING_TYPE_REQUIRES_SUBTYPE);
+    Set<PostFundingDTO> fundings = postDtoCaptor.getValue().getFundings();
+    assertEquals(1, fundings.size());
+    fundings.forEach(funding -> {
+      assertEquals(FUNDING_TYPE_LABEL, funding.getFundingType());
+      assertNull(funding.getFundingSubTypeId());
+    });
+  }
+
+  @Test
   void shouldThrowErrorWhenFundingEndDateIsBeforeStartDate() {
     Calendar calendar = Calendar.getInstance();
     calendar.set(2023, Calendar.JANUARY, 2);
@@ -240,7 +317,7 @@ class PostFundingUpdateTransformerServiceTest {
 
     uploadService.processPostFundingUpdateUpload(Collections.singletonList(postFundingUpdateXls));
 
-    verify(postFundingUpdateXls, times(1))
+    verify(postFundingUpdateXls)
         .addErrorMessage(PostFundingUpdateTransformerService.FUNDING_END_DATE_VALIDATION_MSG);
   }
 
@@ -278,7 +355,7 @@ class PostFundingUpdateTransformerServiceTest {
 
     uploadService.processPostFundingUpdateUpload(Collections.singletonList(postFundingUpdateXls));
 
-    verify(postFundingUpdateXls, times(1))
+    verify(postFundingUpdateXls)
         .addErrorMessage(PostFundingUpdateTransformerService.FUNDING_START_DATE_NULL_OR_EMPTY);
   }
 }


### PR DESCRIPTION
Given the option, users are not adding subtypes.

refactor: reduce parsing iterations

Use of streams provides cleaner separation.
 I expect it is at the cost of performance.

 fix(test): report expected and actuals properly

 Seeing failures reported the wrong way can cause confusion.

 TIS21-8840: Funding Types require Subtypes when available