### PR TITLE
feat: validate funding subtype presence

### DIFF
--- a/generic-upload-api/src/main/java/com/transformuk/hee/tis/genericupload/api/dto/FundingUpdateXLS.java
+++ b/generic-upload-api/src/main/java/com/transformuk/hee/tis/genericupload/api/dto/FundingUpdateXLS.java
@@ -18,17 +18,18 @@ public class FundingUpdateXLS extends TemplateXLS {
   @ExcelColumn(name = "Funding type")
   private String fundingType;
 
+  @ExcelColumn(name = "Funding subtype")
+  private String fundingSubtype;
+
   @ExcelColumn(name = "Funding Details")
   private String fundingTypeOther;
 
   @ExcelColumn(name = "Funding Body")
   private String fundingBody;
 
-  @ExcelColumn(name = "Funding subtype")
-  private String fundingSubtype;
-
   @ExcelColumn(name = "Funding Reason")
   private String fundingReason;
+
   @ExcelColumn(name = "Start Date*", required = true)
   private Date dateFrom;
 

--- a/generic-upload-service/pom.xml
+++ b/generic-upload-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>generic-upload-service</artifactId>
-  <version>1.31.0</version>
+  <version>1.32.0</version>
 
   <packaging>war</packaging>
 

--- a/generic-upload-service/src/main/java/com/transformuk/hee/tis/genericupload/service/service/FundingUpdateTransformerService.java
+++ b/generic-upload-service/src/main/java/com/transformuk/hee/tis/genericupload/service/service/FundingUpdateTransformerService.java
@@ -1,6 +1,7 @@
 package com.transformuk.hee.tis.genericupload.service.service;
 
 import static com.transformuk.hee.tis.genericupload.service.config.MapperConfiguration.convertDate;
+import static com.transformuk.hee.tis.genericupload.service.service.PostFundingUpdateTransformerService.FUNDING_TYPE_REQUIRES_SUBTYPE;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import com.transformuk.hee.tis.genericupload.api.dto.FundingUpdateXLS;
@@ -9,21 +10,26 @@ import com.transformuk.hee.tis.reference.api.dto.TrustDTO;
 import com.transformuk.hee.tis.reference.client.impl.ReferenceServiceImpl;
 import com.transformuk.hee.tis.tcs.api.dto.PostFundingDTO;
 import com.transformuk.hee.tis.tcs.client.service.impl.TcsServiceImpl;
+import java.time.Clock;
 import java.time.LocalDate;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 import org.springframework.web.client.ResourceAccessException;
 
-@Component
+@Service
 public class FundingUpdateTransformerService {
 
   protected static final String POST_FUNDING_ID_AND_POST_ID_NOT_MATCHING =
@@ -44,42 +50,57 @@ public class FundingUpdateTransformerService {
       "Post funding end date must not be equal to or before start date if included.";
   protected static final String ERROR_INVALID_FUNDING_REASON =
       "Funding reason could not be found for the name \"%s\".";
-
   protected static final String UPDATE_FAILED = "Update failed.";
+
   private static final org.slf4j.Logger logger = getLogger(PostUpdateTransformerService.class);
-  private Map<String, UUID> fundingReasonToIdMap = new HashMap<>();
+
+  private final Map<String, UUID> fundingReasonToIdMap = new HashMap<>();
+  private Clock clock = Clock.systemDefaultZone();
 
   @Autowired
   private ReferenceServiceImpl referenceService;
   @Autowired
   private TcsServiceImpl tcsService;
 
-  public void processFundingUpdateUpload(List<FundingUpdateXLS> fundingUpdateXlSs) {
-    fundingUpdateXlSs.forEach(FundingUpdateXLS::initialiseSuccessfullyImported);
+  public void processFundingUpdateUpload(List<FundingUpdateXLS> fundingUpdateXlss) {
+    fundingUpdateXlss.forEach(FundingUpdateXLS::initialiseSuccessfullyImported);
+    Set<String> fundingBodies = new HashSet<>();
+    Set<String> fundingSubTypeLabels = new HashSet<>();
+    Set<String> fundingTypeLabels = new HashSet<>();
+    fundingUpdateXlss.forEach(xls -> {
+      xls.initialiseSuccessfullyImported();
+      Optional.ofNullable(xls.getFundingBody()).ifPresent(fundingBodies::add);
+      Optional.ofNullable(xls.getFundingType()).ifPresent(fundingTypeLabels::add);
+      Optional.ofNullable(xls.getFundingSubtype()).ifPresent(fundingSubTypeLabels::add);
+    });
 
     // Get all funding bodies and retrieve matching funding body IDs.
-    Set<String> fundingBodies = fundingUpdateXlSs.stream()
-        .map(FundingUpdateXLS::getFundingBody).collect(Collectors.toSet());
-    List<TrustDTO> trusts = referenceService.findCurrentTrustsByTrustKnownAsIn(fundingBodies);
-    Map<String, String> fundingBodyNameToId = trusts.stream()
-        .collect(Collectors.toMap(TrustDTO::getTrustKnownAs, dto -> String.valueOf(dto.getId())));
+    Map<String, String> fundingBodyNameToId =
+        referenceService.findCurrentTrustsByTrustKnownAsIn(fundingBodies).stream()
+            .collect(
+                Collectors.toMap(TrustDTO::getTrustKnownAs, dto -> String.valueOf(dto.getId())));
 
     // Get all fundingSubtype and retrieve matching fundingSubtype IDs.
-    Set<String> fundingSubTypeLabels = fundingUpdateXlSs.stream()
-        .map(FundingUpdateXLS::getFundingSubtype).collect(Collectors.toSet());
-    List<FundingSubTypeDto> fundingSubTypes =
-        referenceService.findCurrentFundingSubTypesByLabels(fundingSubTypeLabels);
     // As fundingSubtype label is not unique for all fundingSubtypes,
     // use (fundingType label, fundingSubtype label) from reference service as key.
-    Map<ImmutablePair<String, String>, UUID> fundingSubTypeLabelToId = fundingSubTypes.stream()
-        .collect(Collectors.toMap(
-            dto -> ImmutablePair.of(dto.getFundingType().getLabel().toLowerCase(),
-                dto.getLabel().toLowerCase()),
-            FundingSubTypeDto::getId));
+    Map<ImmutablePair<String, String>, UUID> fundingSubTypeLabelToId =
+        referenceService.findCurrentFundingSubTypesByLabels(fundingSubTypeLabels).stream()
+            .collect(Collectors.toMap(
+                dto -> ImmutablePair.of(dto.getFundingType().getLabel().toLowerCase(),
+                    dto.getLabel().toLowerCase()),
+                FundingSubTypeDto::getId));
+    Map<String, List<FundingSubTypeDto>> fundingTypeToSubtypes =
+        new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+    referenceService.findCurrentFundingTypesByLabelIn(fundingTypeLabels)
+        .forEach(t -> {
+          List<FundingSubTypeDto> subtypes =
+              referenceService.findCurrentFundingSubTypesForFundingTypeId(t.getId());
+          fundingTypeToSubtypes.put(t.getLabel(), subtypes);
+        });
 
-    for (FundingUpdateXLS fundingUpdateXlS : fundingUpdateXlSs) {
+    for (FundingUpdateXLS fundingUpdateXlS : fundingUpdateXlss) {
       useMatchingCriteriaToUpdatePostFunding(fundingUpdateXlS, fundingBodyNameToId,
-          fundingSubTypeLabelToId);
+          fundingSubTypeLabelToId, fundingTypeToSubtypes);
     }
   }
 
@@ -91,11 +112,12 @@ public class FundingUpdateTransformerService {
    *                                service.
    * @param fundingSubTypeLabelToId A mapping of (fundingType, fundingSubType) to fundingSubType
    *                                UUID.
+   * @param fundingTypeToSubtypes   A map containing subtypes for each funding type.
    */
-  private void useMatchingCriteriaToUpdatePostFunding(
-      FundingUpdateXLS fundingUpdateXls,
+  private void useMatchingCriteriaToUpdatePostFunding(FundingUpdateXLS fundingUpdateXls,
       Map<String, String> fundingBodyNameToId,
-      Map<ImmutablePair<String, String>, UUID> fundingSubTypeLabelToId) {
+      Map<ImmutablePair<String, String>, UUID> fundingSubTypeLabelToId,
+      Map<String, List<FundingSubTypeDto>> fundingTypeToSubtypes) {
 
     String postFundingId = fundingUpdateXls.getPostFundingTisId();
 
@@ -106,7 +128,7 @@ public class FundingUpdateTransformerService {
           if (StringUtils.equals(postFundingDto.getPostId().toString(),
               fundingUpdateXls.getPostTisId())) {
             validateAndUpdatePostFundingDto(fundingUpdateXls, postFundingDto, fundingBodyNameToId,
-                fundingSubTypeLabelToId);
+                fundingSubTypeLabelToId, fundingTypeToSubtypes);
           } else {
             fundingUpdateXls
                 .addErrorMessage(String.format(POST_FUNDING_ID_AND_POST_ID_NOT_MATCHING,
@@ -136,22 +158,25 @@ public class FundingUpdateTransformerService {
    *                                service.
    * @param fundingSubTypeLabelToId A mapping of (fundingType, fundingSubType) to fundingSubType
    *                                UUID.
+   * @param fundingTypeToSubtypes   A map containing subtypes for each funding type.
    */
   private void validateAndUpdatePostFundingDto(
       FundingUpdateXLS fundingUpdateXls,
       PostFundingDTO postFundingDto,
       Map<String, String> fundingBodyNameToId,
-      Map<ImmutablePair<String, String>, UUID> fundingSubTypeLabelToId) {
+      Map<ImmutablePair<String, String>, UUID> fundingSubTypeLabelToId,
+      Map<String, List<FundingSubTypeDto>> fundingTypeToSubtypes) {
 
     validateAndUpdateFundingBody(fundingUpdateXls, postFundingDto, fundingBodyNameToId);
-
-    updateFundingType(fundingUpdateXls, postFundingDto);
 
     validateAndUpdateFundingDetails(fundingUpdateXls, postFundingDto);
 
     validateAndUpdateSubType(fundingUpdateXls, postFundingDto, fundingSubTypeLabelToId);
 
     validateFundingStartAndEndDate(fundingUpdateXls, postFundingDto);
+
+    // Validation of type relies on the target DTO containing the updated dates.
+    updateFundingType(fundingUpdateXls, postFundingDto, fundingTypeToSubtypes);
 
     validateAndCacheFundingReasons(fundingUpdateXls, postFundingDto);
 
@@ -188,10 +213,26 @@ public class FundingUpdateTransformerService {
   }
 
   private void updateFundingType(FundingUpdateXLS fundingUpdateXls,
-      PostFundingDTO postFundingDto) {
+      PostFundingDTO postFundingDto, Map<String, List<FundingSubTypeDto>> fundingTypeToSubtypes) {
     final String fundingType = fundingUpdateXls.getFundingType();
     if (StringUtils.isNotEmpty(fundingType)) {
-      postFundingDto.setFundingType(fundingType);
+      /*
+      Rather than using "FundingStatus = CURRENT", the requirement is a subtype is required when:
+      - The funding has not expired (i.e. the end date is null or no earlier than today)
+      - A funding type has been provided
+      - A funding subtype has not been provided
+      - The funding type has subtypes (i.e. the list of subtypes for the funding type is not empty)
+        - A non-existent funding type is treated as having no subtypes
+       */
+      boolean expired = postFundingDto.getEndDate() != null
+          && postFundingDto.getEndDate().isBefore(LocalDate.now(clock));
+      if (!expired
+          && fundingUpdateXls.getFundingSubtype() == null
+          && CollectionUtils.isNotEmpty(fundingTypeToSubtypes.get(fundingType))) {
+        fundingUpdateXls.addErrorMessage(FUNDING_TYPE_REQUIRES_SUBTYPE);
+      } else {
+        postFundingDto.setFundingType(fundingType);
+      }
     }
   }
 
@@ -246,7 +287,6 @@ public class FundingUpdateTransformerService {
   private void validateFundingStartAndEndDate(FundingUpdateXLS fundingUpdateXls,
       PostFundingDTO postFundingDto) {
     LocalDate dateFrom = null;
-    LocalDate dateTo = null;
     if (fundingUpdateXls.getDateFrom() == null && fundingUpdateXls.getDateTo() == null) {
       return;
     }
@@ -261,7 +301,7 @@ public class FundingUpdateTransformerService {
     }
 
     if (fundingUpdateXls.getDateTo() != null && fundingUpdateXls.getDateFrom() != null) {
-      dateTo = convertDate(fundingUpdateXls.getDateTo());
+      LocalDate dateTo = convertDate(fundingUpdateXls.getDateTo());
       if (dateTo != null && dateFrom != null && dateTo.isAfter(dateFrom)) {
         postFundingDto.setEndDate(dateTo);
       } else {
@@ -289,5 +329,9 @@ public class FundingUpdateTransformerService {
       referenceService.findCurrentFundingReasonsByReasonIn(Collections.singleton(fundingReason))
           .forEach(dto -> fundingReasonToIdMap.put(dto.getReason(), dto.getId()));
     }
+  }
+
+  void setClock(Clock clock) {
+    this.clock = clock;
   }
 }

--- a/generic-upload-service/src/main/java/com/transformuk/hee/tis/genericupload/service/service/FundingUpdateTransformerService.java
+++ b/generic-upload-service/src/main/java/com/transformuk/hee/tis/genericupload/service/service/FundingUpdateTransformerService.java
@@ -52,7 +52,7 @@ public class FundingUpdateTransformerService {
       "Funding reason could not be found for the name \"%s\".";
   protected static final String UPDATE_FAILED = "Update failed.";
 
-  private static final org.slf4j.Logger logger = getLogger(PostUpdateTransformerService.class);
+  private static final org.slf4j.Logger logger = getLogger(FundingUpdateTransformerService.class);
 
   private final Map<String, UUID> fundingReasonToIdMap = new HashMap<>();
   private Clock clock = Clock.systemDefaultZone();
@@ -62,8 +62,13 @@ public class FundingUpdateTransformerService {
   @Autowired
   private TcsServiceImpl tcsService;
 
+  /**
+   * Validates and applies valid updates to existing post funding records. Problems are added to the
+   * XLS row.
+   *
+   * @param fundingUpdateXlss List of Spreadsheet rows containing updates for post funding records.
+   */
   public void processFundingUpdateUpload(List<FundingUpdateXLS> fundingUpdateXlss) {
-    fundingUpdateXlss.forEach(FundingUpdateXLS::initialiseSuccessfullyImported);
     Set<String> fundingBodies = new HashSet<>();
     Set<String> fundingSubTypeLabels = new HashSet<>();
     Set<String> fundingTypeLabels = new HashSet<>();

--- a/generic-upload-service/src/test/java/com/transformuk/hee/tis/genericupload/service/service/FundingUpdateTransformerServiceTest.java
+++ b/generic-upload-service/src/test/java/com/transformuk/hee/tis/genericupload/service/service/FundingUpdateTransformerServiceTest.java
@@ -2,10 +2,14 @@ package com.transformuk.hee.tis.genericupload.service.service;
 
 import static com.transformuk.hee.tis.genericupload.service.config.MapperConfiguration.convertDate;
 import static com.transformuk.hee.tis.genericupload.service.service.PostFundingUpdateTransformerService.ERROR_INVALID_FUNDING_REASON;
+import static com.transformuk.hee.tis.genericupload.service.service.PostFundingUpdateTransformerService.FUNDING_TYPE_REQUIRES_SUBTYPE;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.transformuk.hee.tis.genericupload.api.dto.FundingUpdateXLS;
@@ -21,20 +25,20 @@ import java.util.Calendar;
 import java.util.Collections;
 import java.util.UUID;
 import org.hamcrest.CoreMatchers;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
  * The unit tests for {@link FundingUpdateTransformerService}.
  */
-@RunWith(MockitoJUnitRunner.class)
-public class FundingUpdateTransformerServiceTest {
+@ExtendWith(MockitoExtension.class)
+class FundingUpdateTransformerServiceTest {
 
   private static final Long POST_FUNDING_ID = 1L;
   private static final String FUNDING_TYPE_ORIGINAL = "originalType";
@@ -60,17 +64,14 @@ public class FundingUpdateTransformerServiceTest {
   private ArgumentCaptor<PostFundingDTO> postFundingDtoArgumentCaptor;
 
   private FundingUpdateXLS fundingUpdateXls;
-
   private PostFundingDTO postFundingDto;
-
+  private FundingTypeDTO fundingTypeDto;
   private FundingSubTypeDto fundingSubTypeDto;
-
   private FundingReasonDto fundingReasonDto;
 
-  @Before
+  @BeforeEach
   public void setUp() {
 
-    // initialise fundingUpdateXls
     fundingUpdateXls = new FundingUpdateXLS();
     fundingUpdateXls.setPostFundingTisId(POST_FUNDING_ID.toString());
     fundingUpdateXls.setFundingType(FUNDING_TYPE_NEW);
@@ -79,30 +80,17 @@ public class FundingUpdateTransformerServiceTest {
     fundingUpdateXls.setPostTisId("1");
     fundingUpdateXls.setFundingReason(FUNDING_REASON);
     Calendar cFrom = Calendar.getInstance();
-    cFrom.set(2019, Calendar.SEPTEMBER, 1); // 2019-09-01
+    cFrom.set(2019, Calendar.SEPTEMBER, 1);
     fundingUpdateXls.setDateFrom(cFrom.getTime());
     Calendar cTo = Calendar.getInstance();
     cTo.set(2019, Calendar.SEPTEMBER, 2);
     fundingUpdateXls.setDateTo(cTo.getTime());
 
-    // initialise trustDto
-    TrustDTO trustDto = new TrustDTO();
-    trustDto.setTrustKnownAs(FUNDING_BODY_VALID);
-    trustDto.setId(TRUST_ID);
-    when(referenceServiceImpl.findCurrentTrustsByTrustKnownAsIn(
-        Collections.singleton(FUNDING_BODY_VALID)))
-        .thenReturn(Collections.singletonList(trustDto));
-
-    // initialise fundingTypeDto
-    FundingTypeDTO fundingTypeDto = new FundingTypeDTO();
+    fundingTypeDto = new FundingTypeDTO();
+    fundingTypeDto.setId(3L);
     fundingTypeDto.setLabel(FUNDING_TYPE_NEW);
     fundingTypeDto.setAllowDetails(false);
 
-    FundingTypeDTO fundingTypeDto_1 = new FundingTypeDTO();
-    fundingTypeDto_1.setLabel(FUNDING_TYPE_ACADEMIC);
-    fundingTypeDto_1.setAllowDetails(true);
-
-    // initialise postFundingDto
     postFundingDto = new PostFundingDTO();
     postFundingDto.setFundingBodyId("2");
     postFundingDto.setFundingType(FUNDING_TYPE_ORIGINAL);
@@ -122,7 +110,7 @@ public class FundingUpdateTransformerServiceTest {
   }
 
   @Test
-  public void canHandleUnknownPostFundingId() {
+  void canHandleUnknownPostFundingId() {
     String id = "999";
     fundingUpdateXls.setPostFundingTisId(id);
     when(tcsServiceImpl.getPostFundingById(999L)).thenReturn(null);
@@ -136,7 +124,7 @@ public class FundingUpdateTransformerServiceTest {
   }
 
   @Test
-  public void canHandNonNumberPostFundingId() {
+  void canHandNonNumberPostFundingId() {
     String id = "XXX";
     fundingUpdateXls.setPostFundingTisId(id);
 
@@ -149,7 +137,7 @@ public class FundingUpdateTransformerServiceTest {
   }
 
   @Test
-  public void canHandleUnknownFundingBody() {
+  void canHandleUnknownFundingBody() {
     String fundingBodyName = "Unknown";
     fundingUpdateXls.setFundingBody(fundingBodyName);
     when(tcsServiceImpl.getPostFundingById(POST_FUNDING_ID)).thenReturn(postFundingDto);
@@ -164,7 +152,7 @@ public class FundingUpdateTransformerServiceTest {
   }
 
   @Test
-  public void canHandleRequiredFundingTypeWhenDetailsIsFilled() {
+  void canHandleRequiredFundingTypeWhenDetailsIsFilled() {
     fundingUpdateXls.setFundingType(null);
     fundingUpdateXls.setFundingTypeOther("details");
 
@@ -181,7 +169,7 @@ public class FundingUpdateTransformerServiceTest {
   }
 
   @Test
-  public void canHandleUnknownFundingReason() {
+  void canHandleUnknownFundingReason() {
     when(tcsServiceImpl.getPostFundingById(POST_FUNDING_ID)).thenReturn(postFundingDto);
     // Funding Reason not found in Reference Service
     when(referenceServiceImpl.findCurrentFundingReasonsByReasonIn(
@@ -197,8 +185,14 @@ public class FundingUpdateTransformerServiceTest {
 
 
   @Test
-  public void canUpdateFields() {
+  void canUpdateFields() {
     fundingUpdateXls.setFundingSubtype(FUNDING_SUBTYPE);
+    TrustDTO trustDto = new TrustDTO();
+    trustDto.setTrustKnownAs(FUNDING_BODY_VALID);
+    trustDto.setId(TRUST_ID);
+    when(referenceServiceImpl.findCurrentTrustsByTrustKnownAsIn(
+        Collections.singleton(FUNDING_BODY_VALID)))
+        .thenReturn(Collections.singletonList(trustDto));
     when(tcsServiceImpl.getPostFundingById(POST_FUNDING_ID)).thenReturn(postFundingDto);
     when(referenceServiceImpl.findCurrentFundingSubTypesByLabels(
         Collections.singleton(FUNDING_SUBTYPE)))
@@ -231,7 +225,7 @@ public class FundingUpdateTransformerServiceTest {
   }
 
   @Test
-  public void ShouldNotUpdateFieldsWhenNull() {
+  void shouldNotUpdateFieldsWhenNull() {
     fundingUpdateXls.setFundingType(null);
     fundingUpdateXls.setFundingTypeOther(null);
     fundingUpdateXls.setFundingBody(null);
@@ -257,17 +251,24 @@ public class FundingUpdateTransformerServiceTest {
         equalTo(postFundingDto.getStartDate()));
     assertThat("Should not update dateTo", postFundingDtoArgumentCaptorValue.getEndDate(),
         equalTo(postFundingDto.getEndDate()));
-    assertThat("Should not update fundingReason", postFundingDtoArgumentCaptorValue.getFundingReasonId(),
+    assertThat("Should not update fundingReason",
+        postFundingDtoArgumentCaptorValue.getFundingReasonId(),
         equalTo(postFundingDto.getFundingReasonId()));
   }
 
   @Test
-  public void shouldUpdateInfoToNullWhenFundingDetailsAreEmpty() {
+  void shouldUpdateInfoToNullWhenFundingDetailsAreEmpty() {
 
     postFundingDto.setFundingBodyId("2");
     postFundingDto.setFundingType(FUNDING_TYPE_ACADEMIC);
     postFundingDto.setInfo("info");
     postFundingDto.setId(2L);
+    TrustDTO trustDto = new TrustDTO();
+    trustDto.setTrustKnownAs(FUNDING_BODY_VALID);
+    trustDto.setId(TRUST_ID);
+    when(referenceServiceImpl.findCurrentTrustsByTrustKnownAsIn(
+        Collections.singleton(FUNDING_BODY_VALID)))
+        .thenReturn(Collections.singletonList(trustDto));
     when(tcsServiceImpl.getPostFundingById(2L)).thenReturn(postFundingDto);
 
     fundingUpdateXls.setPostFundingTisId("2");
@@ -290,7 +291,7 @@ public class FundingUpdateTransformerServiceTest {
   }
 
   @Test
-  public void shouldGiveErrorWhenPostIdDoesNotMatch() {
+  void shouldGiveErrorWhenPostIdDoesNotMatch() {
     String postId = "999";
     fundingUpdateXls.setPostTisId(postId);
     when(tcsServiceImpl.getPostFundingById(POST_FUNDING_ID)).thenReturn(postFundingDto);
@@ -303,7 +304,7 @@ public class FundingUpdateTransformerServiceTest {
   }
 
   @Test
-  public void canHandleRequiredFundingTypeWhenFundingSubtypeIsFilled() {
+  void shouldErrorWhenFundingSubtypeIsFilledAndFundingTypeEmpty() {
     fundingUpdateXls.setFundingTypeOther(null);
     fundingUpdateXls.setFundingType(null);
     fundingUpdateXls.setFundingSubtype(FUNDING_SUBTYPE);
@@ -319,7 +320,73 @@ public class FundingUpdateTransformerServiceTest {
   }
 
   @Test
-  public void shouldUpdateFundingSubtypeIdToNullWhenFundingFundingSubtypeLabelIsEmpty() {
+  void shouldErrorWhenFundingSubtypeIsRequiredAndMissing() {
+    fundingUpdateXls.setDateTo(null);
+    TrustDTO trustDto = new TrustDTO();
+    trustDto.setTrustKnownAs(FUNDING_BODY_VALID);
+    trustDto.setId(TRUST_ID);
+    when(referenceServiceImpl.findCurrentTrustsByTrustKnownAsIn(
+        Collections.singleton(FUNDING_BODY_VALID)))
+        .thenReturn(Collections.singletonList(trustDto));
+    when(tcsServiceImpl.getPostFundingById(POST_FUNDING_ID)).thenReturn(postFundingDto);
+    when(referenceServiceImpl.findCurrentFundingSubTypesByLabels(Collections.emptySet()))
+        .thenReturn(Collections.singletonList(fundingSubTypeDto));
+    when(referenceServiceImpl.findCurrentFundingTypesByLabelIn(
+        Collections.singleton(FUNDING_TYPE_NEW)))
+        .thenReturn(Collections.singletonList(fundingTypeDto));
+    when(referenceServiceImpl.findCurrentFundingSubTypesForFundingTypeId(fundingTypeDto.getId()))
+        .thenReturn(Collections.singletonList(fundingSubTypeDto));
+    when(referenceServiceImpl.findCurrentFundingReasonsByReasonIn(
+        Collections.singleton(FUNDING_REASON)))
+        .thenReturn(Collections.singletonList(fundingReasonDto));
+
+    fundingUpdateTransformerService
+        .processFundingUpdateUpload(Collections.singletonList(fundingUpdateXls));
+    verify(tcsServiceImpl, never()).updateFunding(any());
+    assertThat(fundingUpdateXls.getErrorMessage(), containsString(FUNDING_TYPE_REQUIRES_SUBTYPE));
+  }
+
+  @Test
+  void shouldNotErrorWhenFundingSubtypeIsNotRequiredAndMissing() {
+    fundingUpdateXls.setDateTo(null);
+    TrustDTO trustDto = new TrustDTO();
+    trustDto.setTrustKnownAs(FUNDING_BODY_VALID);
+    trustDto.setId(TRUST_ID);
+    when(referenceServiceImpl.findCurrentTrustsByTrustKnownAsIn(
+        Collections.singleton(FUNDING_BODY_VALID)))
+        .thenReturn(Collections.singletonList(trustDto));
+    when(tcsServiceImpl.getPostFundingById(POST_FUNDING_ID)).thenReturn(postFundingDto);
+    when(referenceServiceImpl.findCurrentFundingSubTypesByLabels(Collections.emptySet()))
+        .thenReturn(Collections.singletonList(fundingSubTypeDto));
+    when(referenceServiceImpl.findCurrentFundingTypesByLabelIn(
+        Collections.singleton(FUNDING_TYPE_NEW)))
+        .thenReturn(Collections.singletonList(fundingTypeDto));
+    when(referenceServiceImpl.findCurrentFundingSubTypesForFundingTypeId(fundingTypeDto.getId()))
+        .thenReturn(Collections.emptyList());
+    when(referenceServiceImpl.findCurrentFundingReasonsByReasonIn(
+        Collections.singleton(FUNDING_REASON)))
+        .thenReturn(Collections.singletonList(fundingReasonDto));
+    when(tcsServiceImpl.updateFunding(postFundingDtoArgumentCaptor.capture()))
+        .thenReturn(postFundingDto);
+
+    fundingUpdateTransformerService
+        .processFundingUpdateUpload(Collections.singletonList(fundingUpdateXls));
+    PostFundingDTO postFundingDtoArgumentCaptorValue = postFundingDtoArgumentCaptor.getValue();
+
+    assertThat(postFundingDtoArgumentCaptorValue.getFundingType(),
+        equalTo(fundingUpdateXls.getFundingType()));
+    assertThat(postFundingDtoArgumentCaptorValue.getInfo(), equalTo(FUNDING_TYPE_OTHER));
+    assertThat(postFundingDtoArgumentCaptorValue.getFundingBodyId(), equalTo("1"));
+    assertThat(postFundingDtoArgumentCaptorValue.getStartDate(),
+        equalTo(convertDate(fundingUpdateXls.getDateFrom())));
+    assertThat(postFundingDtoArgumentCaptorValue.getFundingSubTypeId(),
+        nullValue());
+    assertThat(postFundingDtoArgumentCaptorValue.getFundingReasonId(),
+        equalTo(FUNDING_REASON_UUID));
+  }
+
+  @Test
+  void shouldUpdateFundingSubtypeIdToNullWhenFundingFundingSubtypeLabelIsEmpty() {
 
     postFundingDto.setFundingType(FUNDING_TYPE_ACADEMIC);
     postFundingDto.setFundingSubTypeId(FUNDING_SUBTYPE_ID);
@@ -329,6 +396,12 @@ public class FundingUpdateTransformerServiceTest {
     fundingUpdateXls.setPostFundingTisId("2");
     fundingUpdateXls.setFundingType(FUNDING_TYPE_NEW);
 
+    TrustDTO trustDto = new TrustDTO();
+    trustDto.setTrustKnownAs(FUNDING_BODY_VALID);
+    trustDto.setId(TRUST_ID);
+    when(referenceServiceImpl.findCurrentTrustsByTrustKnownAsIn(
+        Collections.singleton(FUNDING_BODY_VALID)))
+        .thenReturn(Collections.singletonList(trustDto));
     when(tcsServiceImpl.updateFunding(postFundingDtoArgumentCaptor.capture()))
         .thenReturn(postFundingDto);
     when(referenceServiceImpl.findCurrentFundingReasonsByReasonIn(
@@ -347,7 +420,7 @@ public class FundingUpdateTransformerServiceTest {
   }
 
   @Test
-  public void shouldErrorWhenFundingSubTypeNotFound() {
+  void shouldErrorWhenFundingSubTypeNotFound() {
     fundingUpdateXls.setFundingSubtype(FUNDING_SUBTYPE);
     when(tcsServiceImpl.getPostFundingById(POST_FUNDING_ID)).thenReturn(postFundingDto);
     when(referenceServiceImpl.findCurrentFundingSubTypesByLabels(
@@ -366,7 +439,7 @@ public class FundingUpdateTransformerServiceTest {
   }
 
   @Test
-  public void shouldThrowErrorWhenFundingEndDateIsBeforeStartDate() {
+  void shouldThrowErrorWhenFundingEndDateIsBeforeStartDate() {
     Calendar cTo = Calendar.getInstance();
     cTo.set(2019, Calendar.JANUARY, 2);
     fundingUpdateXls.setDateTo(cTo.getTime());

--- a/generic-upload-service/src/test/java/com/transformuk/hee/tis/genericupload/service/service/FundingUpdateTransformerServiceTest.java
+++ b/generic-upload-service/src/test/java/com/transformuk/hee/tis/genericupload/service/service/FundingUpdateTransformerServiceTest.java
@@ -330,7 +330,7 @@ class FundingUpdateTransformerServiceTest {
         .thenReturn(Collections.singletonList(trustDto));
     when(tcsServiceImpl.getPostFundingById(POST_FUNDING_ID)).thenReturn(postFundingDto);
     when(referenceServiceImpl.findCurrentFundingSubTypesByLabels(Collections.emptySet()))
-        .thenReturn(Collections.singletonList(fundingSubTypeDto));
+        .thenReturn(Collections.emptyList());
     when(referenceServiceImpl.findCurrentFundingTypesByLabelIn(
         Collections.singleton(FUNDING_TYPE_NEW)))
         .thenReturn(Collections.singletonList(fundingTypeDto));

--- a/generic-upload-service/src/test/java/com/transformuk/hee/tis/genericupload/service/service/PostFundingUpdateTransformerServiceTest.java
+++ b/generic-upload-service/src/test/java/com/transformuk/hee/tis/genericupload/service/service/PostFundingUpdateTransformerServiceTest.java
@@ -29,9 +29,14 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InjectMocks;
@@ -236,12 +241,14 @@ class PostFundingUpdateTransformerServiceTest {
     verify(postFundingUpdateXls).addErrorMessage(ERROR_FUNDING_TYPE_IS_REQUIRED_FOR_SUB_TYPE);
   }
 
-  @Test
-  void shouldAddErrorWhenFundingTypeRequiresSubtypeButSubtypeMissing() {
+  @ParameterizedTest
+  @NullSource
+  @MethodSource("getEndDatesWhenFundingSubtypeRequired")
+  void shouldAddErrorWhenFundingTypeRequiresSubtypeButSubtypeMissing(Date endDate) {
     when(postFundingUpdateXls.getFundingType()).thenReturn(FUNDING_TYPE_LABEL);
     when(postFundingUpdateXls.getFundingSubtype()).thenReturn(null);
     when(postFundingUpdateXls.getErrorMessage()).thenReturn(FUNDING_TYPE_REQUIRES_SUBTYPE);
-    when(postFundingUpdateXls.getDateTo()).thenReturn(Date.from(CLOCK.instant().minusSeconds(40)));
+    when(postFundingUpdateXls.getDateTo()).thenReturn(endDate);
 
     when(referenceServiceMock.findCurrentFundingTypesByLabelIn(
         Collections.singleton(FUNDING_TYPE_LABEL)))
@@ -360,5 +367,9 @@ class PostFundingUpdateTransformerServiceTest {
 
     verify(postFundingUpdateXls)
         .addErrorMessage(PostFundingUpdateTransformerService.FUNDING_START_DATE_NULL_OR_EMPTY);
+  }
+
+  public static Stream<Arguments> getEndDatesWhenFundingSubtypeRequired() {
+    return Stream.of(Arguments.of(Date.from(CLOCK.instant().minusSeconds(40))));
   }
 }


### PR DESCRIPTION
**N.B.** Product decision to leave existing bugs to be picked up later.

The earlier commits operate on Post Funding Create files. This commit checks that an update leaves a record passing validation.

chore(test): bump Junit v4 -> v5

TIS21-8840: Funding Types require Subtypes when available